### PR TITLE
Remove absolute QUÉtudes-info links

### DIFF
--- a/404.html
+++ b/404.html
@@ -50,69 +50,69 @@
 
             <div id="header">
                 <div class="banner index-banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg"
+                    <a href="/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg"
                             alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                 </div>
                 <div class="header-right index-rheader">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
                     <a id="header-disclaimers"
-                        href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms
+                        href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms
                         of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav index-topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language
                                         CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives
                                         to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing
                                         a CEGEP and Program</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart
                                         choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important
+                                <li><a href="/quetudesinfo/apply/important-dates">Important
                                         Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application
+                                <li><a href="/quetudesinfo/apply/application-systems">Application
                                         Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After
+                                <li><a href="/quetudesinfo/apply/after-applying">After
                                         applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
                                 <li><a
-                                        href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                                        href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms
                                         of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info:
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info:
                                         The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site
+                                <li><a href="/quetudesinfo/about/about-me">About the site
                                         creator</a></li>
                             </ul>
                         </li>
@@ -128,7 +128,7 @@
             <div class="custom-container" id="404-msg">
                 <h1 class="mt-3 mb-4"><strong>404: Page Not Found</strong></h1>
                 <h3 class="p-0 mb-3">Hmm, we can't seem to find the page you're looking for—sorry about that!</h3>
-                <h4><em>Check out the <a href="https://cw118.github.io/quetudesinfo/">homepage</a>, or take a look at our sitemap below to get started:</em></h4>
+                <h4><em>Check out the <a href="/quetudesinfo/">homepage</a>, or take a look at our sitemap below to get started:</em></h4>
             </div>
 
             <table class="table table-striped table-bordered container text-center" id="404-sitemap">
@@ -140,83 +140,83 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/">Home</a></th>
+                        <th scope="row"><a href="/quetudesinfo/">Home</a></th>
                         <td>Welcome! If you're not sure where to begin, the homepage suggests some starting points.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a></th>
+                        <th scope="row"><a href="/quetudesinfo/whatiscegep">What is CEGEP</a></th>
                         <td>Overview of Quebec's education system and what CEGEP is.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></th>
+                        <th scope="row"><a href="/quetudesinfo/whatiscegep/programs">Programs</a></th>
                         <td>In-depth explanations of important vocabulary and introduction to the basics of CEGEP programs.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></th>
+                        <th scope="row"><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></th>
                         <td>Concise list and descriptions of CEGEPs offering English instruction.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></th>
+                        <th scope="row"><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></th>
                         <td>Detailed dissection of CEGEP R-Scores, their purpose, and what we know about R-Score calculations.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></th>
+                        <th scope="row"><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></th>
                         <td>Brief rundown of post-secondary alternatives (options other than CEGEP).</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a></th>
+                        <th scope="row"><a href="/quetudesinfo/apply">Applying to CEGEP</a></th>
                         <td>Explanation of CEGEP admissions and introduction to CEGEP applications.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></th>
+                        <th scope="row"><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></th>
                         <td>Tips on choosing a CEGEP and program.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></th>
+                        <th scope="row"><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></th>
                         <td>Strategies and things to keep in mind for CEGEP applications.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></th>
+                        <th scope="row"><a href="/quetudesinfo/apply/important-dates">Important Dates</a></th>
                         <td>Event calendar with dates to remember for CEGEP applicants.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></th>
+                        <th scope="row"><a href="/quetudesinfo/apply/application-systems">Application Systems</a></th>
                         <td>Comprehensive guide to applying to CEGEP, with instructions specific to each application system.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></th>
+                        <th scope="row"><a href="/quetudesinfo/apply/after-applying">After applying</a></th>
                         <td>What comes after submitting applications and clarification of CEGEP General Education requirements.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></th>
+                        <th scope="row"><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></th>
                         <td>Compare pre-university programs (prerequisites and course material) side-by-side with ease.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></th>
+                        <th scope="row"><a href="/quetudesinfo/links">Important Links</a></th>
                         <td>Links to official websites and helpful resources on CEGEP, from viewbooks to application modules.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/resources">Resources</a></th>
+                        <th scope="row"><a href="/quetudesinfo/resources">Resources</a></th>
                         <td>Free web resources for a variety of subjects.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About: Disclaimers and Terms</a></th>
+                        <th scope="row"><a href="/quetudesinfo/about/disclaimers-terms">About: Disclaimers and Terms</a></th>
                         <td>Important information including disclaimers, licenses and terms of use.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></th>
+                        <th scope="row"><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></th>
                         <td>About the project: find out more about what inspired QUÉtudes-info, as well as why and how this site was created.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></th>
+                        <th scope="row"><a href="/quetudesinfo/about/about-me">About the site creator</a></th>
                         <td>About me, the student behind QUÉtudes-info.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/help">Help and FAQ</a></th>
+                        <th scope="row"><a href="/quetudesinfo/help">Help and FAQ</a></th>
                         <td>Find answers to commonly-asked questions concerning CEGEP (FAQ) and a simple sitemap.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/contact">Contact</a></th>
+                        <th scope="row"><a href="/quetudesinfo/contact">Contact</a></th>
                         <td>Contact form coming soon! You'll still be able to find us on <a href="https://github.com/cw118/quetudesinfo" target="_blank">GitHub</a> though.</td>
                     </tr>
                 </tbody>
@@ -226,29 +226,29 @@
                 <div class="footer-row">
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language
+                            <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language
                                     CEGEPs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a>
+                            <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a>
                             </li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison
                                     Tool</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a
+                            <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a
                                     CEGEP and Program</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application
+                            <li><a href="/quetudesinfo/apply/application-systems">Application
                                     Systems</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/links">Important Links</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and
+                            <li><a href="/quetudesinfo/help">Help</a></li>
+                            <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and
                                     Terms</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a>
+                            <li><a href="/quetudesinfo/about/about-project">About the project</a>
                             </li>
                         </ul>
                     </div>

--- a/about/about-me.html
+++ b/about/about-me.html
@@ -47,50 +47,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms" class="active">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms" class="active">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -109,14 +109,14 @@
                 <a class="nav-link" href="#links">Links</a>
                 <hr>
                 <p class="sidenav-title">In this section</p>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms of Use</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a>
-                <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a>
+                <a class="nav-link" href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms of Use</a>
+                <a class="nav-link" href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a>
+                <a class="nav-link active" href="/quetudesinfo/about/about-me">About the site creator</a>
             </nav>
 
             <section class="text-consolas">
                 <div class="pagination mb-2" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/about/about-project" class="btn btn-info previous">&#8592; About the project</a>
+                    <a href="/quetudesinfo/about/about-project" class="btn btn-info previous">&#8592; About the project</a>
                     <a href="#" class="btn btn-warning next hide">Next &#8594;</a>
                 </div>
 
@@ -140,7 +140,7 @@
 
                 <h2 class="cadetblue-bg" id="cs50-cs">CS50 and Computer Science</h2>
                 <p>I began CS50's Introduction to Computer Science, a free Harvard course available on edX and their OpenCourseWare (both
-                linked <a href="#links">below</a> and in the <a href="https://cw118.github.io/quetudesinfo/resources" target="_blank">Resources section</a>), in early July. I highly recommend CS50 for anyone interested in coding and
+                linked <a href="#links">below</a> and in the <a href="/quetudesinfo/resources" target="_blank">Resources section</a>), in early July. I highly recommend CS50 for anyone interested in coding and
                 computer science—it's nicely structured and provides you with a strong skill set that you'll find indispensable even
                 beyond the course.</p>
                 <div class="image-label">
@@ -156,8 +156,8 @@
                 <p>Once I'd watched all the lectures and completed every lab and problem set, the last step was the final project. I really
                 liked the idea of helping others better understand CEGEP, as well as sharing my knowledge on the subject with others,
                 since I'd been doing research on the topic for such a long time. So I chose to create the QUÉtudes-info website as my
-                final project <em>(read more about how I made the site <a href="https://cw118.github.io/quetudesinfo/about/about-project">here</a>)</em>. I'd also been thinking about a tool that allowed people to
-                compare CEGEP programs side-by-side, and thanks to CS50, I was actually able to make this tool myself <em>(see the <a href="https://cw118.github.io/quetudesinfo/compare-programs" target="_blank">Program
+                final project <em>(read more about how I made the site <a href="/quetudesinfo/about/about-project">here</a>)</em>. I'd also been thinking about a tool that allowed people to
+                compare CEGEP programs side-by-side, and thanks to CS50, I was actually able to make this tool myself <em>(see the <a href="/quetudesinfo/compare-programs" target="_blank">Program
                 Comparison Tool</a>)</em>.</p>
                 <p>I learned so much as I developed QUÉtudes-info, both about CEGEP and web development. Web programming, for me, combines
                 creativity, logic and technology into one discipline—I love how it allows you to be artistic and mathematical/scientific
@@ -184,7 +184,7 @@
                 <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
 
                 <div class="pagination" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/about/about-project" class="btn btn-info previous">&#8592; About the project</a>
+                    <a href="/quetudesinfo/about/about-project" class="btn btn-info previous">&#8592; About the project</a>
                     <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
                     <a href="#" class="btn btn-warning next hide">Next &#8594;</a>
                 </div>
@@ -196,23 +196,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/about/about-project.html
+++ b/about/about-project.html
@@ -52,46 +52,46 @@
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms" class="active">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms" class="active">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -111,15 +111,15 @@
                 <a class="nav-link" href="#project-links">Project Links</a>
                 <hr>
                 <p class="sidenav-title">In this section</p>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms of Use</a>
-                <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a>
+                <a class="nav-link" href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms of Use</a>
+                <a class="nav-link active" href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a>
+                <a class="nav-link" href="/quetudesinfo/about/about-me">About the site creator</a>
             </nav>
 
             <section class="text-consolas">
                 <div class="pagination mb-2" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms" class="btn btn-info previous">&#8592; Disclaimers and Terms</a>
-                    <a href="https://cw118.github.io/quetudesinfo/about/about-me" class="btn btn-info next">About the site creator &#8594;</a>
+                    <a href="/quetudesinfo/about/disclaimers-terms" class="btn btn-info previous">&#8592; Disclaimers and Terms</a>
+                    <a href="/quetudesinfo/about/about-me" class="btn btn-info next">About the site creator &#8594;</a>
                 </div>
 
                 <h2 class="salmon-bg" id="the-project">QUÉtudes-info: The Project</h2>
@@ -145,7 +145,7 @@
                 looking to improve the implementation of this webpage as I learn more and gain more experience coding websites. But for
                 now, this should do!</p>
                 <p>QUÉtudes-info was created as my final project for Harvard University's CS50's Introduction to Computer Science course,
-                which I talk about more in <a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a>. I completed QUÉtudes-info on my own—the research, design, and code
+                which I talk about more in <a href="/quetudesinfo/about/about-me">About the site creator</a>. I completed QUÉtudes-info on my own—the research, design, and code
                 <em>(which I admit is a little messy)</em> was all done by me. It was fun, rewarding, and admittedly tiring, but overall a
                 wonderful learning and coding experience. Now I hope QUÉtudes-info will help others, and that maybe I'll get the time
                 and chance to organize and improve my code for this site.</p>
@@ -180,9 +180,9 @@
                 <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
 
                 <div class="pagination" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms" class="btn btn-info previous">&#8592; Disclaimers and Terms</a>
+                    <a href="/quetudesinfo/about/disclaimers-terms" class="btn btn-info previous">&#8592; Disclaimers and Terms</a>
                     <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                    <a href="https://cw118.github.io/quetudesinfo/about/about-me" class="btn btn-info next">About the site creator &#8594;</a>
+                    <a href="/quetudesinfo/about/about-me" class="btn btn-info next">About the site creator &#8594;</a>
                 </div>
 
             </section>
@@ -192,23 +192,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/about/disclaimers-terms.html
+++ b/about/disclaimers-terms.html
@@ -46,49 +46,49 @@
                 
                 <div id="header">
                     <div class="banner">
-                        <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
+                        <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                     </div>
                     <div class="header-right">
-                        <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                        <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                        <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                        <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                        <a id="header-help" href="/quetudesinfo/help">Help</a>
+                        <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                        <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                        <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                     </div>
                 </div>   
                 
                 <nav class="topnav">
                     <div id="topnav-end">
                         <ul class="nav-links">
-                            <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                            <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown1">                                    
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                                 </ul>
                             </li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown2">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                    <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                    <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                    <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                    <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                    <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                                 </ul>
                             </li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms" class="active">About &#9662;</a>
+                                <a href="/quetudesinfo/about/disclaimers-terms" class="active">About &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown3">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                    <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                    <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                                 </ul>
                             </li>
                         </ul>
@@ -106,9 +106,9 @@
                     <a class="nav-link" href="#terms">Terms of Use</a>
                     <hr>
                     <p class="sidenav-title">In this section</p>
-                    <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms of Use</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a>
+                    <a class="nav-link active" href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms of Use</a>
+                    <a class="nav-link" href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a>
+                    <a class="nav-link" href="/quetudesinfo/about/about-me">About the site creator</a>
                 </nav>
         
                 <section class="text-roboto-condensed">
@@ -146,9 +146,9 @@
                     </ol>
                     
                     <div class="pagination" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms" class="btn btn-info previous hide">&#8592; Previous</a>
+                        <a href="/quetudesinfo/about/disclaimers-terms" class="btn btn-info previous hide">&#8592; Previous</a>
                         <a href="#" class="btn btn-secondary back-to-top show-always">Back to top &#8593;</a>
-                        <a href="https://cw118.github.io/quetudesinfo/about/about-project" class="btn btn-info next">About the project &#8594;</a>
+                        <a href="/quetudesinfo/about/about-project" class="btn btn-info next">About the project &#8594;</a>
                     </div>
         
                 </section>
@@ -158,23 +158,23 @@
                 <div class="footer-row">
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                            <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                            <li><a href="/quetudesinfo/links">Important Links</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                            <li><a href="/quetudesinfo/help">Help</a></li>
+                            <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                            <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                         </ul>
                     </div>
                 </div>

--- a/about/index.html
+++ b/about/index.html
@@ -48,69 +48,69 @@
 
             <div id="header">
                 <div class="banner index-banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg"
+                    <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg"
                             alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                 </div>
                 <div class="header-right index-rheader">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
                     <a id="header-disclaimers"
-                        href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms
+                        href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms
                         of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav index-topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language
                                         CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives
                                         to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing
                                         a CEGEP and Program</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart
                                         choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important
+                                <li><a href="/quetudesinfo/apply/important-dates">Important
                                         Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application
+                                <li><a href="/quetudesinfo/apply/application-systems">Application
                                         Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After
+                                <li><a href="/quetudesinfo/apply/after-applying">After
                                         applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
                                 <li><a
-                                        href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                                        href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms
                                         of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info:
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info:
                                         The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site
+                                <li><a href="/quetudesinfo/about/about-me">About the site
                                         creator</a></li>
                             </ul>
                         </li>
@@ -129,7 +129,7 @@
             <div class="custom-container" id="404-msg">
                 <h1 class="mt-3 mb-4"><strong>404: Page Not Found</strong></h1>
                 <h3 class="p-0 mb-3">Hmm, we can't seem to find the page you're looking for—sorry about that!</h3>
-                <h4><em>Check out the <a href="https://cw118.github.io/quetudesinfo/">homepage</a>, or take a look at
+                <h4><em>Check out the <a href="/quetudesinfo/">homepage</a>, or take a look at
                         our sitemap below to get started:</em></h4>
             </div>
 
@@ -142,109 +142,109 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/">Home</a></th>
+                        <th scope="row"><a href="/quetudesinfo/">Home</a></th>
                         <td>Welcome! If you're not sure where to begin, the homepage suggests some starting points.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a>
+                        <th scope="row"><a href="/quetudesinfo/whatiscegep">What is CEGEP</a>
                         </th>
                         <td>Overview of Quebec's education system and what CEGEP is.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>
+                        <th scope="row"><a href="/quetudesinfo/whatiscegep/programs">Programs</a>
                         </th>
                         <td>In-depth explanations of important vocabulary and introduction to the basics of CEGEP
                             programs.</td>
                     </tr>
                     <tr>
                         <th scope="row"><a
-                                href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language
+                                href="/quetudesinfo/whatiscegep/english-cegeps">English-language
                                 CEGEPs</a></th>
                         <td>Concise list and descriptions of CEGEPs offering English instruction.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The
+                        <th scope="row"><a href="/quetudesinfo/whatiscegep/r-score">The
                                 R-Score</a></th>
                         <td>Detailed dissection of CEGEP R-Scores, their purpose, and what we know about R-Score
                             calculations.</td>
                     </tr>
                     <tr>
                         <th scope="row"><a
-                                href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives
+                                href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives
                                 to CEGEP</a></th>
                         <td>Brief rundown of post-secondary alternatives (options other than CEGEP).</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a></th>
+                        <th scope="row"><a href="/quetudesinfo/apply">Applying to CEGEP</a></th>
                         <td>Explanation of CEGEP admissions and introduction to CEGEP applications.</td>
                     </tr>
                     <tr>
                         <th scope="row"><a
-                                href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a
+                                href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a
                                 CEGEP and Program</a></th>
                         <td>Tips on choosing a CEGEP and program.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making
+                        <th scope="row"><a href="/quetudesinfo/apply/make-smart-choices">Making
                                 smart choices</a></th>
                         <td>Strategies and things to keep in mind for CEGEP applications.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important
+                        <th scope="row"><a href="/quetudesinfo/apply/important-dates">Important
                                 Dates</a></th>
                         <td>Event calendar with dates to remember for CEGEP applicants.</td>
                     </tr>
                     <tr>
                         <th scope="row"><a
-                                href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application
+                                href="/quetudesinfo/apply/application-systems">Application
                                 Systems</a></th>
                         <td>Comprehensive guide to applying to CEGEP, with instructions specific to each application
                             system.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After
+                        <th scope="row"><a href="/quetudesinfo/apply/after-applying">After
                                 applying</a></th>
                         <td>What comes after submitting applications and clarification of CEGEP General Education
                             requirements.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program
+                        <th scope="row"><a href="/quetudesinfo/compare-programs">Program
                                 Comparison Tool</a></th>
                         <td>Compare pre-university programs (prerequisites and course material) side-by-side with ease.
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></th>
+                        <th scope="row"><a href="/quetudesinfo/links">Important Links</a></th>
                         <td>Links to official websites and helpful resources on CEGEP, from viewbooks to application
                             modules.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/resources">Resources</a></th>
+                        <th scope="row"><a href="/quetudesinfo/resources">Resources</a></th>
                         <td>Free web resources for a variety of subjects.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About:
+                        <th scope="row"><a href="/quetudesinfo/about/disclaimers-terms">About:
                                 Disclaimers and Terms</a></th>
                         <td>Important information including disclaimers, licenses and terms of use.</td>
                     </tr>
                     <tr>
                         <th scope="row"><a
-                                href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The
+                                href="/quetudesinfo/about/about-project">QUÉtudes-info: The
                                 Project</a></th>
                         <td>About the project: find out more about what inspired QUÉtudes-info, as well as why and how
                             this site was created.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site
+                        <th scope="row"><a href="/quetudesinfo/about/about-me">About the site
                                 creator</a></th>
                         <td>About me, the student behind QUÉtudes-info.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/help">Help and FAQ</a></th>
+                        <th scope="row"><a href="/quetudesinfo/help">Help and FAQ</a></th>
                         <td>Find answers to commonly-asked questions concerning CEGEP (FAQ) and a simple sitemap.</td>
                     </tr>
                     <tr>
-                        <th scope="row"><a href="https://cw118.github.io/quetudesinfo/contact">Contact</a></th>
+                        <th scope="row"><a href="/quetudesinfo/contact">Contact</a></th>
                         <td>Contact form coming soon! You'll still be able to find us on <a
                                 href="https://github.com/cw118/quetudesinfo" target="_blank">GitHub</a> though.</td>
                     </tr>
@@ -255,29 +255,29 @@
                 <div class="footer-row">
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language
+                            <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language
                                     CEGEPs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a>
+                            <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a>
                             </li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison
                                     Tool</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a
+                            <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a
                                     CEGEP and Program</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application
+                            <li><a href="/quetudesinfo/apply/application-systems">Application
                                     Systems</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/links">Important Links</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and
+                            <li><a href="/quetudesinfo/help">Help</a></li>
+                            <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and
                                     Terms</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a>
+                            <li><a href="/quetudesinfo/about/about-project">About the project</a>
                             </li>
                         </ul>
                     </div>

--- a/apply/after-applying.html
+++ b/apply/after-applying.html
@@ -47,49 +47,49 @@
                 
                 <div id="header">
                     <div class="banner">
-                        <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
+                        <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                     </div>
                     <div class="header-right">
-                        <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                        <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                        <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                        <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                        <a id="header-help" href="/quetudesinfo/help">Help</a>
+                        <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                        <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                        <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                     </div>
                 </div>   
                 
                 <nav class="topnav">
                     <div id="topnav-end">
                         <ul class="nav-links">
-                            <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                            <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown1">                                    
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                                 </ul>
                             </li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown2">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                    <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                    <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                    <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                    <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                    <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                                 </ul>
                             </li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                                <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown3">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                    <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                    <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                                 </ul>
                             </li>
                         </ul>
@@ -109,17 +109,17 @@
                     <a class="nav-link" href="#college-course-overview">Overview of College Courses</a>
                     <hr>
                     <p class="sidenav-title">In this section</p>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>
-                    <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a>
+                    <a class="nav-link" href="/quetudesinfo/apply">Applying to CEGEP</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/important-dates">Important Dates</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/application-systems">Application Systems</a>
+                    <a class="nav-link active" href="/quetudesinfo/apply/after-applying">After applying</a>
                 </nav>
         
                 <section>
                     <div class="pagination mb-2" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/apply/application-systems" class="btn btn-warning previous">&#8592; Previous</a>
                     </div>
 
                     <h2 class="skyblue-bg" id="after-applying">After applying</h2>
@@ -206,7 +206,7 @@
                     view and download your college schedules, access your course grades and more. <strong>Make sure to check the platform (log in to your student portal) periodically</strong>, and to fulfill any requirements (submit
                     documents, etc.) listed there.</p>
                     <hr>
-                    <p>And that's all you really need to know about CEGEP applications and follow-ups! We hope you found this section and <a href="https://cw118.github.io/quetudesinfo/apply/application-systems">our
+                    <p>And that's all you really need to know about CEGEP applications and follow-ups! We hope you found this section and <a href="/quetudesinfo/apply/application-systems">our
                     Application Systems page</a> helpful.</p>
                     <p>Next up are some details about what comes after getting admitted to a college, including placement tests and a basic
                     guide to the CEGEP courses required for graduation.</p>
@@ -408,7 +408,7 @@
                         <li><strong>PE 102 courses may include</strong> <em>(NOT offered at every CEGEP)</em>: Badminton, Basketball, Cycling Skills, Fitness, Aquatics, Cross Country Skiing, Golf...</li>
                         <li><strong>PE 103 courses may include</strong> <em>(NOT offered at every CEGEP)</em>: Cardio Dance, Core Training, Nature Retreat, Soccer, Winter Camping, Team Sports…</li>
                     </ul>
-                    <p class="sources">Sources: <a href="https://cw118.github.io/quetudesinfo/links">CEGEP application guides, course lists and calendars</a>, <a href="https://www.bemarianopolis.ca/programs/">bemarianopolis</a>, <a href="https://www.johnabbott.qc.ca/program-structure/">John Abbott College</a>, <a href="https://www.cegepsquebec.ca/en/cegeps/presentation/systeme-scolaire-quebecois/grille-de-cours-et-ponderation/">Cégeps du Québec</a></p>
+                    <p class="sources">Sources: <a href="/quetudesinfo/links">CEGEP application guides, course lists and calendars</a>, <a href="https://www.bemarianopolis.ca/programs/">bemarianopolis</a>, <a href="https://www.johnabbott.qc.ca/program-structure/">John Abbott College</a>, <a href="https://www.cegepsquebec.ca/en/cegeps/presentation/systeme-scolaire-quebecois/grille-de-cours-et-ponderation/">Cégeps du Québec</a></p>
                     <hr>
                     <p><i class="fas fa-star"></i> <strong><u>Final reminder to frequently check your CEGEP student portal!</u></strong></p>
                     <h4 style="line-height: 1.5; margin-bottom: 0;">And that's it for QUÉtudes-info's guide to CEGEP programs, admissions, and applications! <strong>We hope you've found our site helpful—if you did, share it with your friends and classmates so that everyone can
@@ -417,14 +417,14 @@
                     learning.</strong></p>
                     <p class="p-disclaimer skyblue-bg"><i class="fas fa-share"></i> <em>Share this link with your classmates:</em> <span id="site-link">https://cw118.github.io/quetudesinfo/</span> </p>
                     <hr><p class="mb-1">Curious about the student behind the QUÉtudes-info site?</p>
-                    <p><a href="https://cw118.github.io/quetudesinfo/about/about-me" class="btn btn-success">About the site creator</a></p>
+                    <p><a href="/quetudesinfo/about/about-me" class="btn btn-success">About the site creator</a></p>
                     <p class="mb-1">Want to learn more about the QUÉtudes-info project and how it was created?</p>
-                    <p><a href="https://cw118.github.io/quetudesinfo/about/about-project" class="btn btn-dark">QUÉtudes-info: About the project</a></p>
+                    <p><a href="/quetudesinfo/about/about-project" class="btn btn-dark">QUÉtudes-info: About the project</a></p>
 
                     <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
                     
                     <div class="pagination" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/apply/application-systems" class="btn btn-warning previous">&#8592; Previous</a>
                         <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
                         <a href="#" class="btn btn-warning next hide">Next &#8594;</a>
                     </div>
@@ -436,23 +436,23 @@
                 <div class="footer-row">
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                            <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                            <li><a href="/quetudesinfo/links">Important Links</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                            <li><a href="/quetudesinfo/help">Help</a></li>
+                            <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                            <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                         </ul>
                     </div>
                 </div>

--- a/apply/application-systems.html
+++ b/apply/application-systems.html
@@ -46,49 +46,49 @@
                 
                 <div id="header">
                     <div class="banner">
-                        <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
+                        <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                     </div>
                     <div class="header-right">
-                        <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                        <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                        <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                        <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                        <a id="header-help" href="/quetudesinfo/help">Help</a>
+                        <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                        <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                        <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                     </div>
                 </div>   
                 
                 <nav class="topnav">
                     <div id="topnav-end">
                         <ul class="nav-links">
-                            <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                            <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown1">                                    
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                                 </ul>
                             </li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown2">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                    <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                    <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                    <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                    <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                    <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                                 </ul>
                             </li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                                <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown3">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                    <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                    <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                                 </ul>
                             </li>
                         </ul>
@@ -110,18 +110,18 @@
                     <a class="nav-link" href="#finished-applying">Finished applying?</a>
                     <hr>
                     <p class="sidenav-title">In this section</p>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a>
-                    <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a>
+                    <a class="nav-link" href="/quetudesinfo/apply">Applying to CEGEP</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/important-dates">Important Dates</a>
+                    <a class="nav-link active" href="/quetudesinfo/apply/application-systems">Application Systems</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/after-applying">After applying</a>
                 </nav>
         
                 <section>
                     <div class="pagination mb-2" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/apply/important-dates" class="btn btn-warning previous">&#8592; Previous</a>
-                        <a href="https://cw118.github.io/quetudesinfo/apply/after-applying" class="btn btn-warning next">Next &#8594;</a>
+                        <a href="/quetudesinfo/apply/important-dates" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/apply/after-applying" class="btn btn-warning next">Next &#8594;</a>
                     </div>
 
                     <h2 class="skyblue-bg" id="application-systems">Application Systems</h2>
@@ -161,15 +161,15 @@
                         <li><strong>Print a copy/take a screenshot of your completed application</strong> (print out the transmission receipt, if available)</li>
                         <li><strong>Take note of and write down your reference number</strong> (your "application number")</li>
                         <li><strong>If you're sending documents by email or mail, indicate your reference number!</strong></li>
-                        <li><u>Information on topics such as checking your application status and confirming your acceptance will be covered in <a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After
+                        <li><u>Information on topics such as checking your application status and confirming your acceptance will be covered in <a href="/quetudesinfo/apply/after-applying">After
                         applying</a>.</u></li>
                     </ul>
                     <p><strong>Ready for application walkthroughs? To begin, scroll to an application system and click on the title banner to display the instructions.</strong></p>
                     <hr>
                     <p class="mb-1">Want to learn more about CEGEP and CEGEP programs before learning how to apply?</p>
-                    <p><a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="btn btn-primary">What is CEGEP</a></p>
-                    <p>Want to find out more on CEGEP admissions and how applications are evaluated? See <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>.</p>
-                    <p>Looking for some tips on choosing a CEGEP and/or program? Try <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>.</p>
+                    <p><a href="/quetudesinfo/whatiscegep" class="btn btn-primary">What is CEGEP</a></p>
+                    <p>Want to find out more on CEGEP admissions and how applications are evaluated? See <a href="/quetudesinfo/apply">Applying to CEGEP</a>.</p>
+                    <p>Looking for some tips on choosing a CEGEP and/or program? Try <a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>.</p>
 
                     <a class="btn w-100" href="#sram" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="sram"><h2 class="mb-0" id="sram-title">SRAM</h2></a>
                     <div id="sram" class="collapse">
@@ -430,7 +430,7 @@
                             </li>
                             <li>Deadline: March 1, 11:59 pm</li>
                             <li>You can check the college's admissions updates here: <a href="https://www.bemarianopolis.ca/admissions/admissions-updates/" target="_blank">https://www.bemarianopolis.ca/admissions/admissions-updates/</a></li>
-                            <li>Consult the "Application Handbook" section in the <a href="https://cw118.github.io/quetudesinfo/links#viewbooks" target="_blank">college's viewbook</a> for information on applications</li>
+                            <li>Consult the "Application Handbook" section in the <a href="/quetudesinfo/links#viewbooks" target="_blank">college's viewbook</a> for information on applications</li>
                         </ul>
                         <p><i class="fas fa-star"></i> <strong>You can apply to Marianopolis College at this link:</strong> <a href="https://www.bemarianopolis.ca/admissions/apply-now/" target="_blank">https://www.bemarianopolis.ca/admissions/apply-now/</a></p>
                         <hr>
@@ -475,7 +475,7 @@
                             <li>$30 application fee</li>
                             <li>Deadline: March 1, 11:59 pm</li>
                             <li>You can access Champlain St-Lambert's guides to applying and Table of Programs of Study here: <a href="https://www.champlainonline.com/champlainweb/future-students/apply-to-champlain/" target="_blank">https://www.champlainonline.com/champlainweb/future-students/apply-to-champlain/</a></li>
-                            <li>Consult the "How To Apply?" section in <a href="https://cw118.github.io/quetudesinfo/links#viewbooks" target="_blank">Champlain St-Lambert's admissions handbook</a> as needed</li>
+                            <li>Consult the "How To Apply?" section in <a href="/quetudesinfo/links#viewbooks" target="_blank">Champlain St-Lambert's admissions handbook</a> as needed</li>
                         </ul>
                         <p><i class="fas fa-star"></i> <strong>You can apply to Champlain St-Lambert at this link:</strong> <a href="https://champlaincollege-st-lambert-admission-en.omnivox.ca/" target="_blank">https://champlaincollege-st-lambert-admission-en.omnivox.ca/</a></p>
                         <p><i class="fas fa-star"></i> <strong>Or apply to Champlain St-Lawrence at this link:</strong> <a href="https://slc-admission-en.omnivox.ca/" target="_blank">https://slc-admission-en.omnivox.ca/</a></p>
@@ -530,14 +530,14 @@
                     <p>Have you submitted all of your CEGEP applications? Well, first of all, <strong>congratulations</strong>—though you're not quite done yet. CEGEPs tend to start responding around mid-March/beginning of April, though this
                     varies with each college, and you'll want to <strong>check your application status</strong> (check for updates). We'll go over this and more on the next page, <a href="after-applying.html">After applying</a>.</p>
                     <p class="text-blue"><em>This page was created in September 2021 (updated February 2022).</em></p>
-                    <p class="sources">Sources: <a href="https://www.bemarianopolis.ca/admissions/">bemarianopolis Admissions</a>, <a href="https://cw118.github.io/quetudesinfo/links#application-links">application system simulations, sites and guides</a></p>
+                    <p class="sources">Sources: <a href="https://www.bemarianopolis.ca/admissions/">bemarianopolis Admissions</a>, <a href="/quetudesinfo/links#application-links">application system simulations, sites and guides</a></p>
 
                     <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
                     
                     <div class="pagination" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/apply/important-dates" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/apply/important-dates" class="btn btn-warning previous">&#8592; Previous</a>
                         <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                        <a href="https://cw118.github.io/quetudesinfo/apply/after-applying" class="btn btn-warning next">Next &#8594;</a>
+                        <a href="/quetudesinfo/apply/after-applying" class="btn btn-warning next">Next &#8594;</a>
                     </div>
         
                 </section>
@@ -547,23 +547,23 @@
                 <div class="footer-row">
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                            <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                            <li><a href="/quetudesinfo/links">Important Links</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                            <li><a href="/quetudesinfo/help">Help</a></li>
+                            <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                            <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                         </ul>
                     </div>
                 </div>

--- a/apply/choose-a-cegep-program.html
+++ b/apply/choose-a-cegep-program.html
@@ -47,50 +47,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -109,18 +109,18 @@
                 <a class="nav-link" href="#factors-program">Factors to consider: Program</a>
                 <hr>
                 <p class="sidenav-title">In this section</p>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>
-                <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a>
+                <a class="nav-link" href="/quetudesinfo/apply">Applying to CEGEP</a>
+                <a class="nav-link active" href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
+                <a class="nav-link" href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
+                <a class="nav-link" href="/quetudesinfo/apply/important-dates">Important Dates</a>
+                <a class="nav-link" href="/quetudesinfo/apply/application-systems">Application Systems</a>
+                <a class="nav-link" href="/quetudesinfo/apply/after-applying">After applying</a>
             </nav>
 
             <section>
                 <div class="pagination mb-2" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/apply" class="btn btn-warning previous">&#8592; Previous</a>
-                    <a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/apply" class="btn btn-warning previous">&#8592; Previous</a>
+                    <a href="/quetudesinfo/apply/make-smart-choices" class="btn btn-warning next">Next &#8594;</a>
                 </div>
 
                 <h2 class="skyblue-bg" id="choose">Choosing a CEGEP and Program</h2>
@@ -131,7 +131,7 @@
                 how they match up to your personality. (We'll look at this in more depth in the <a href="#factors-cegep">Factors to consider</a> parts of this page.)</p>
                 <p>It's also important to keep in mind that many CEGEPs give you two choices on their application, so you'll likely want to
                 identify two or three programs of interest for each college. Formulating strategies and back-up plans will be key for
-                CEGEP applications. (We'll discuss this more in <a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a>.)</p>
+                CEGEP applications. (We'll discuss this more in <a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a>.)</p>
 
                 <h2 class="yellow-bg" id="factors-cegep">Factors to consider: CEGEP</h2>
                 <p>Since you should always apply to multiple CEGEPs, this part is more to help you determine which ones could be the best
@@ -165,7 +165,7 @@
                 fees</u> (amounts vary by institution). You'll also want to keep <strong>textbook costs</strong> in mind, as those are never included in
                 student fee totals.</p>
                 <p><em>*To verify whether you qualify as a Quebec resident, see this form: <a href="https://www.dawsoncollege.qc.ca/public/services/finance_department/quebecresidenceformenglish.pdf" target="_blank">https://www.dawsoncollege.qc.ca/public/services/finance_department/quebecresidenceformenglish.pdf</a></em></p>
-                <p>**This site does <strong>not</strong> provide financial information on any school. Visit the <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">official sites</a> for information on tuition,
+                <p>**This site does <strong>not</strong> provide financial information on any school. Visit the <a href="/quetudesinfo/links" target="_blank">official sites</a> for information on tuition,
                 scholarships, financial aid and the like.</p>
                 
                 <h3 class="orange-bg mb-2">Program Options</h3>
@@ -223,7 +223,7 @@
 
                 <h2 class="skyblue-bg" id="factors-program">Factors to consider: Program</h2>
                 <p>Choosing a program isn't always easy. Maybe you're unsure of what you like, of what path you want to take, or you don't
-                know what options are out there. (<em>If it's the latter, check out our <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a> section, which has information on CEGEPs, programs, and more.</em>)</p>
+                know what options are out there. (<em>If it's the latter, check out our <a href="/quetudesinfo/whatiscegep">What is CEGEP</a> section, which has information on CEGEPs, programs, and more.</em>)</p>
                 <p>And without further ado, here are some factors to consider when choosing a CEGEP program.</p>
 
                 <h3 class="goldenrod-bg mb-2">Type of program</h3>
@@ -247,7 +247,7 @@
                 <p>Some common additional prerequisites are: Secondary V Math SN/TS* (506), Secondary V Physics (504), Secondary V
                 Chemistry (504), Letter of Intent, Portfolio. A few programs may even require an interview.</p>
                 <p><u>Program prerequisites can be found on official CEGEP sites and in their
-                viewbooks</u>, the links to which you can find at <a href="https://cw118.github.io/quetudesinfo/links">Important Links</a>. (<em>Our <a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a> also lists prerequisites,
+                viewbooks</u>, the links to which you can find at <a href="/quetudesinfo/links">Important Links</a>. (<em>Our <a href="/quetudesinfo/compare-programs">Program Comparison Tool</a> also lists prerequisites,
                 but we recommend visiting official sites and resources to confirm.</em>)</p>
                 <p><em>*SN Math is commonly referred to as "scientific math" or "math science option". For youth sector secondary school
                 students in Quebec, 6-credit math courses should meet the math prerequisite, but please double-check to confirm that you
@@ -260,7 +260,7 @@
                 <p>CEGEPs will post grade minimums online (some programs don't necessarily have any), which you'll want to look over if
                 they're available. <i class="fas fa-exclamation"></i> <strong>Note that the real cutoffs are calculated based on the grades of the previous year's applicants and tend to
                 change every year. These "real" cutoffs are <u>NOT</u> the ones found online or in viewbooks.</strong></p>
-                <p><em>You may also find the <a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a> on QUÉtudes-info helpful, as it lists prerequisites and cutoffs specified by CEGEPs on their websites, viewbooks, program brochures and more.</em></p>
+                <p><em>You may also find the <a href="/quetudesinfo/compare-programs">Program Comparison Tool</a> on QUÉtudes-info helpful, as it lists prerequisites and cutoffs specified by CEGEPs on their websites, viewbooks, program brochures and more.</em></p>
 
                 <h3 class="silver-bg mb-2">Passions and interests</h3>
                 <p>Here are some simple but significant questions to reflect on: What drives you? What piques your curiosity? What
@@ -317,14 +317,14 @@
                 others and empathizing with them comes naturally to you… the list of possibilities goes on and on. <strong>Get to know yourself and understand who you are</strong>—interests, hobbies, values, goals, skills, character traits and habits—it's all part of exploring your personality and
                 what the future holds for you.</p>
                 <hr>
-                <p><i class="fas fa-info-circle"></i> Tip: try comparing pre-university programs with our <a href="https://cw118.github.io/quetudesinfo/compare-programs" target="_blank" class="btn btn-primary">Program Comparison Tool</a></p>
+                <p><i class="fas fa-info-circle"></i> Tip: try comparing pre-university programs with our <a href="/quetudesinfo/compare-programs" target="_blank" class="btn btn-primary">Program Comparison Tool</a></p>
 
                 <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
 
                 <div class="pagination" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/apply" class="btn btn-warning previous">&#8592; Previous</a>
+                    <a href="/quetudesinfo/apply" class="btn btn-warning previous">&#8592; Previous</a>
                     <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                    <a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/apply/make-smart-choices" class="btn btn-warning next">Next &#8594;</a>
                 </div>
 
             </section>
@@ -334,23 +334,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/apply/important-dates.html
+++ b/apply/important-dates.html
@@ -46,49 +46,49 @@
                 
                 <div id="header">
                     <div class="banner">
-                        <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
+                        <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                     </div>
                     <div class="header-right">
-                        <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                        <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                        <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                        <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                        <a id="header-help" href="/quetudesinfo/help">Help</a>
+                        <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                        <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                        <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                     </div>
                 </div>   
                 
                 <nav class="topnav">
                     <div id="topnav-end">
                         <ul class="nav-links">
-                            <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                            <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown1">                                    
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                                 </ul>
                             </li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown2">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                    <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                    <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                    <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                    <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                    <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                                 </ul>
                             </li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                                <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown3">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                    <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                    <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                                 </ul>
                             </li>
                         </ul>
@@ -110,24 +110,24 @@
                     <a class="nav-link" href="#mar22">March 2022</a>
                     <hr>
                     <p class="sidenav-title">In this section</p>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
-                    <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a>
+                    <a class="nav-link" href="/quetudesinfo/apply">Applying to CEGEP</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
+                    <a class="nav-link active" href="/quetudesinfo/apply/important-dates">Important Dates</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/application-systems">Application Systems</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/after-applying">After applying</a>
                 </nav>
         
                 <section>
                     <div class="pagination mb-2" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices" class="btn btn-warning previous">&#8592; Previous</a>
-                        <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" class="btn btn-warning next">Next &#8594;</a>
+                        <a href="/quetudesinfo/apply/make-smart-choices" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/apply/application-systems" class="btn btn-warning next">Next &#8594;</a>
                     </div>
                     
                     <h2 class="skyblue-bg" id="dates">Important Dates</h2>
-                    <p>A condensed calendar of important events and deadlines for CEGEP applicants, parents, and curious students. For <strong>links to official CEGEP sites and (virtual) open house sites, see <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">Important Links</a></strong> (opens in a new tab).</p>
+                    <p>A condensed calendar of important events and deadlines for CEGEP applicants, parents, and curious students. For <strong>links to official CEGEP sites and (virtual) open house sites, see <a href="/quetudesinfo/links" target="_blank">Important Links</a></strong> (opens in a new tab).</p>
                     <p><u>Student-for-a-Day</u> visits can usually be scheduled at individual CEGEPs from October to February (time period/months vary for each
-                    college). <strong>Visit the <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">official sites</a> for details and to register.</strong></p>
+                    college). <strong>Visit the <a href="/quetudesinfo/links" target="_blank">official sites</a> for details and to register.</strong></p>
                     <p class="lightyellow-bg p-disclaimer"><i class="fas fa-info-circle"></i> As of January 17, application modules for Marianopolis, SRAM (Vanier, John Abbott, Heritage, Champlain Lennoxville), Dawson, and Champlain St-Lambert are open (accepting applications). Remember that it is <strong>not</strong> first-come first-serve, and that <strong>the deadline to apply is March 1!</strong></p>
 
                     <h2 class="orange-bg" id="oct21">October 2021 <i class="fas fa-football-ball"></i></h2>                    
@@ -185,7 +185,7 @@
                             </div>
                             <div class="details">
                                 <h3>Fall 2022 Deadline</h3>
-                                <p>High school students and more: the 2022 Fall semester application deadline is <u>Tuesday, March 1, 2022</u>. <a href="https://cw118.github.io/quetudesinfo/links#application-links" target="_blank">CEGEP application
+                                <p>High school students and more: the 2022 Fall semester application deadline is <u>Tuesday, March 1, 2022</u>. <a href="/quetudesinfo/links#application-links" target="_blank">CEGEP application
                                     modules</a> will open in mid-January. <a href="https://www.sram.qc.ca/diploma-of-college-studies/deadlines-and-important-dates" target="_blank">Go to SRAM's website to see round 2 and round 3 deadlines.</a></p>
                             </div>
                         </div>
@@ -194,9 +194,9 @@
                     <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
                     
                     <div class="pagination" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/apply/make-smart-choices" class="btn btn-warning previous">&#8592; Previous</a>
                         <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                        <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" class="btn btn-warning next">Next &#8594;</a>
+                        <a href="/quetudesinfo/apply/application-systems" class="btn btn-warning next">Next &#8594;</a>
                     </div>
         
                 </section>
@@ -206,23 +206,23 @@
                 <div class="footer-row">
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                            <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                            <li><a href="/quetudesinfo/links">Important Links</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                            <li><a href="/quetudesinfo/help">Help</a></li>
+                            <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                            <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                         </ul>
                     </div>
                 </div>

--- a/apply/index.html
+++ b/apply/index.html
@@ -47,50 +47,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -108,18 +108,18 @@
                 <a class="nav-link" href="#admissions">Admissions: Evaluating applicants</a>
                 <a class="nav-link" href="#conditional-acceptance">Conditional Acceptance</a>
                 <p class="sidenav-title">In this section</p>
-                <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a>
+                <a class="nav-link active" href="/quetudesinfo/apply">Applying to CEGEP</a>
+                <a class="nav-link" href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
+                <a class="nav-link" href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
+                <a class="nav-link" href="/quetudesinfo/apply/important-dates">Important Dates</a>
+                <a class="nav-link" href="/quetudesinfo/apply/application-systems">Application Systems</a>
+                <a class="nav-link" href="/quetudesinfo/apply/after-applying">After applying</a>
             </nav>
 
             <section>
                 <div class="pagination mb-2" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="btn btn-info previous">Previous: What is CEGEP</a>
-                    <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/whatiscegep" class="btn btn-info previous">Previous: What is CEGEP</a>
+                    <a href="/quetudesinfo/apply/choose-a-cegep-program" class="btn btn-warning next">Next &#8594;</a>
                 </div>
                 <h2 class="skyblue-bg" id="applying">Applying to CEGEP</h2>
                 <p class="p-disclaimer lightyellow-bg"><i class="fas fa-info-circle"></i> Please note that the pages in this section contain general guidelines, and that following them does <u>not</u> guarantee any outcomes, including but not
@@ -149,8 +149,8 @@
                 </ul>
                 <hr>
                 <p><strong>Want to learn more about CEGEP and CEGEP programs before learning how to apply?</strong></p>
-                <p><a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="btn btn-primary">What is CEGEP</a></p>
-                <p><strong>Want to find out how to apply to various CEGEPs straight away? Skip to <a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>.</strong></p>
+                <p><a href="/quetudesinfo/whatiscegep" class="btn btn-primary">What is CEGEP</a></p>
+                <p><strong>Want to find out how to apply to various CEGEPs straight away? Skip to <a href="/quetudesinfo/apply/application-systems">Application Systems</a>.</strong></p>
 
                 <h2 class="yellow-bg" id="admissions">Admissions: Evaluating applicants</h2>
                 <p class="p-disclaimer"><i class="fas fa-info-circle"></i> Disclaimer: This section does not describe the exact process taken by any CEGEP admissions team and is meant to give a
@@ -169,7 +169,7 @@
 
                 <h3 class="mb-2" id="sram-admissions">SRAM: Vanier, John Abbott, Champlain Lennoxville, Heritage</h3>
                 <p><em>SRAM stands for Service régional d'admission du Montréal métropolitain, and students can apply to several CEGEPs through
-                SRAM. See <a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a> for more details.</em></p>
+                SRAM. See <a href="/quetudesinfo/apply/application-systems">Application Systems</a> for more details.</em></p>
                 <div class="image-label">
                     <img src="https://admission.sram.qc.ca/static/sram/hibou_transp.png" class="logo-img" alt="SRAM logo">
                     <p class="caption">Brandmark &#169; SRAM</p>
@@ -178,7 +178,7 @@
                 <p>SRAM-affiliated CEGEPs use <strong>ranking lists</strong> when evaluating applications to determine the eligibility of applicants, to
                 compare them to one another, and to select the best-suited candidates for limited enrolment programs. <em>To see how SRAM determines these rankings, <a href="https://sram.qc.ca/frequently-asked-questions" target="_blank">visit their FAQ</a>.</em></p>
                 <h3 class="mb-1 lightyellow-bg">Other CEGEPs</h3>
-                <p>Other CEGEPs calculate varying averages, such as an overall average, when evaluating applicants. For more details on this, try contacting the admissions teams, asking during information sessions, and/or talking to your guidance counsellor. <em>You can also try consulting the CEGEP websites, which can be found at <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
+                <p>Other CEGEPs calculate varying averages, such as an overall average, when evaluating applicants. For more details on this, try contacting the admissions teams, asking during information sessions, and/or talking to your guidance counsellor. <em>You can also try consulting the CEGEP websites, which can be found at <a href="/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
 
                 <h2 class="yellow-bg" id="conditional-acceptance">Conditional Acceptance</h2>
                 <p>CEGEPs look at <strong>all of your secondary 4 and 5 grades, including the final term of secondary 5</strong> <em>(typically the third term
@@ -188,15 +188,15 @@
                 acceptance means that <u>there are still requirements, or conditions, that you must fulfill by the end of the school year
                 for your acceptance to be finalized</u>. In other words, your final high school grades must also meet the requirements and
                 you must complete all of your college program prerequisites in order to keep your spot at a CEGEP.</p>
-                <p><em>(You can learn more about this in <a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a>.)</em></p>
+                <p><em>(You can learn more about this in <a href="/quetudesinfo/apply/after-applying">After applying</a>.)</em></p>
                 <p class="sources">Sources: <a href="https://sram.qc.ca/frequently-asked-questions">SRAM FAQ</a>, <a href="https://loyola.ca/images/articlemedia/students/2019-2020/2020_-_CEGEP_Applications__Parent.pdf">Loyola High School — 2020 CEGEP Applications</a>, documents from various high schools, notes from previous CEGEP information sessions</p>
 
                 <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
 
                 <div class="pagination" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="btn btn-info previous">Previous: What is CEGEP</a>
+                    <a href="/quetudesinfo/whatiscegep" class="btn btn-info previous">Previous: What is CEGEP</a>
                     <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                    <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/apply/choose-a-cegep-program" class="btn btn-warning next">Next &#8594;</a>
                 </div>
 
             </section>
@@ -206,23 +206,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/apply/make-smart-choices.html
+++ b/apply/make-smart-choices.html
@@ -46,49 +46,49 @@
                 
                 <div id="header">
                     <div class="banner">
-                        <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
+                        <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                     </div>
                     <div class="header-right">
-                        <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                        <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                        <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                        <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                        <a id="header-help" href="/quetudesinfo/help">Help</a>
+                        <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                        <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                        <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                     </div>
                 </div>   
                 
                 <nav class="topnav">
                     <div id="topnav-end">
                         <ul class="nav-links">
-                            <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                            <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown1">                                    
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                                 </ul>
                             </li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/apply" class="active">Applying to CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown2">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                    <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                    <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                    <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                    <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                    <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                                 </ul>
                             </li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                                <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown3">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                    <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                    <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                                 </ul>
                             </li>
                         </ul>
@@ -109,21 +109,21 @@
                     <a class="nav-link" href="#summary-takeaways">Summary and Takeaways</a>
                     <hr>
                     <p class="sidenav-title">In this section</p>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
-                    <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a>
+                    <a class="nav-link" href="/quetudesinfo/apply">Applying to CEGEP</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
+                    <a class="nav-link active" href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/important-dates">Important Dates</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/application-systems">Application Systems</a>
+                    <a class="nav-link" href="/quetudesinfo/apply/after-applying">After applying</a>
                 </nav>
         
                 <section>
                     <div class="pagination mb-2" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program" class="btn btn-warning previous">&#8592; Previous</a>
-                        <a href="https://cw118.github.io/quetudesinfo/apply/important-dates" class="btn btn-warning next">Next &#8594;</a>
+                        <a href="/quetudesinfo/apply/choose-a-cegep-program" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/apply/important-dates" class="btn btn-warning next">Next &#8594;</a>
                     </div>
 
-                    <p><i class="fas fa-exclamation"></i><i class="fas fa-exclamation"></i> <strong>This page is a continuation of "Choosing a CEGEP and Program". If you haven't read that page yet, check it out here: <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>.</strong></p>
+                    <p><i class="fas fa-exclamation"></i><i class="fas fa-exclamation"></i> <strong>This page is a continuation of "Choosing a CEGEP and Program". If you haven't read that page yet, check it out here: <a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>.</strong></p>
                     <h2 class="skyblue-bg" id="choosing-smart">Making smart choices</h2>
                     <p>There are certain strategies and things to keep in mind when you plan for and begin the application process. It's safer
                     to <strong>avoid making any assumptions</strong> when you're applying to CEGEP—don't be overconfident about where you'll get accepted.
@@ -149,7 +149,7 @@
 
                     <h2 class="skyblue-bg" id="practise-applying">Practice Applications</h2>
                     <p>There are a few different application systems, most of which, if not all, give you the option of completing an
-                    <strong>application simulation</strong>. (We'll go over the application systems in more detail on the next page, <a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>.) If
+                    <strong>application simulation</strong>. (We'll go over the application systems in more detail on the next page, <a href="/quetudesinfo/apply/application-systems">Application Systems</a>.) If
                     a simulation option is available, it is highly recommended that you <strong>do a practice run</strong>—familiarize yourself with the
                     module, know what you'll need to apply (documents and more), and reduce the stress experienced during the real
                     applications by going through the actual process risk-free. Just <strong>remember to submit a real application afterwards!</strong></p>
@@ -161,7 +161,7 @@
                     </div>
 
                     <h2 class="yellow-bg" id="second-choice-programs">Second-choice programs</h2>
-                    <p>Many application modules require you to <strong>provide two program options</strong> right away (again, more on this in <a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a>). There are some strategies when it comes to choosing the second option, since you don't want to select one
+                    <p>Many application modules require you to <strong>provide two program options</strong> right away (again, more on this in <a href="/quetudesinfo/apply/application-systems">Application Systems</a>). There are some strategies when it comes to choosing the second option, since you don't want to select one
                     that's harder to get into than your first choice. In short, <strong>a second-choice program should be easier to get into than
                     your first choice</strong>.</p>
                     <p>When applying (and asked to provide two program choices), <strong>AVOID</strong> the following combinations:</p>
@@ -199,7 +199,7 @@
                     <p>So, we repeat: <strong>do <u>NOT</u> choose the above combinations</strong> when applying to CEGEP! Always keep in mind that <strong>a second-choice program should be easier to get into than your first choice</strong>.</p>
 
                     <h2 class="skyblue-bg" id="summary-takeaways">Summary and Takeaways</h2>
-                    <p>Here's a summary of the first three pages of the Applying to CEGEP section (<a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>, <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and
+                    <p>Here's a summary of the first three pages of the Applying to CEGEP section (<a href="/quetudesinfo/apply">Applying to CEGEP</a>, <a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and
                     Program</a>, Making smart choices): the "Must Knows" of CEGEP admissions and applications in general.</p>
                     <p class="p-disclaimer lightyellow-bg"><i class="fas fa-info-circle"></i> Please note that these are general guidelines and that following them does <u>not</u> guarantee any outcomes, including but not
                     limited to successful completion of an application, successful submission of an application, admission to a college,
@@ -223,7 +223,7 @@
                         <li>Do you wish to study this field after CEGEP, or to find a career in this field?</li>
                         <li><strong>Do I have/meet all of the program requirements?</strong></li>
                     </ul>
-                    <p>See <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a> for more details.</p><br>
+                    <p>See <a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a> for more details.</p><br>
                     <p>A <strong>program's prerequisites and cutoffs (requirements)</strong> are determining factors in CEGEP admissions. Here are some important things to check and look out for when choosing a
                     program/applying to CEGEP.</p>
                     <p><strong>If you:</strong></p>
@@ -276,15 +276,15 @@
                     </ul>
                     <p class="sources">Sources: <a href="https://loyola.ca/images/articlemedia/students/2019-2020/2020_-_CEGEP_Applications__Parent.pdf">Loyola High School — 2020 CEGEP Applications</a>, documents from various high schools, notes from previous CEGEP information sessions</p>
                     <hr>
-                    <p><strong>Want to see some important dates, including deadlines and open houses?</strong> Continue to <strong><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></strong>.</p>
-                    <p><strong>Ready to learn about each CEGEP's application system/how to actually apply?</strong> Go to <strong><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></strong>.</p>
+                    <p><strong>Want to see some important dates, including deadlines and open houses?</strong> Continue to <strong><a href="/quetudesinfo/apply/important-dates">Important Dates</a></strong>.</p>
+                    <p><strong>Ready to learn about each CEGEP's application system/how to actually apply?</strong> Go to <strong><a href="/quetudesinfo/apply/application-systems">Application Systems</a></strong>.</p>
 
                     <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
                     
                     <div class="pagination" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/apply/choose-a-cegep-program" class="btn btn-warning previous">&#8592; Previous</a>
                         <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                        <a href="https://cw118.github.io/quetudesinfo/apply/important-dates" class="btn btn-warning next">Next &#8594;</a>
+                        <a href="/quetudesinfo/apply/important-dates" class="btn btn-warning next">Next &#8594;</a>
                     </div>
         
                 </section>
@@ -294,23 +294,23 @@
                 <div class="footer-row">
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                            <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                            <li><a href="/quetudesinfo/links">Important Links</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                            <li><a href="/quetudesinfo/help">Help</a></li>
+                            <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                            <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                         </ul>
                     </div>
                 </div>

--- a/compare-programs.html
+++ b/compare-programs.html
@@ -38,7 +38,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/qinfo-icon.svg">
             
     <title>Program Comparison Tool | QUÉtudes-info</title>
-    <link rel="canonical" href="https://cw118.github.io/quetudesinfo/compare-programs">
+    <link rel="canonical" href="/quetudesinfo/compare-programs">
 </head>
 
 <body>
@@ -48,50 +48,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs" class="active">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs" class="active">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -110,7 +110,7 @@
                 <p>The <strong><a class="link-darkblue" href="#tool-title">Program Comparison Tool</a></strong> allows you to select two CEGEP programs and compare their <u>prerequisites, cutoffs and
                     other admission requirements</u> side-by-side, as well as their <u>program grids</u>: all of the program-specific credits students must
                     obtain over the course of the program. <em>At the moment, the tool only has data for pre-university
-                    programs at 8 colleges, but you can find the CEGEP viewbooks at <a href="https://cw118.github.io/quetudesinfo/links">Important Links</a>, where
+                    programs at 8 colleges, but you can find the CEGEP viewbooks at <a href="/quetudesinfo/links">Important Links</a>, where
                     technical programs are presented in detail.</em></p>
             </div>
 
@@ -185,11 +185,11 @@
                                 under both menus. Clear the textbox to select another program (you may also select another college). Repeat the
                                 process for the second CEGEP program using the second set of menus.</p>
                             <p><strong>Note that general CEGEP entrance requirements</strong> (basic prerequisites for all CEGEP programs)
-                                <strong>are the Quebec Secondary School diploma requirements. See <a href="https://cw118.github.io/quetudesinfo/whatiscegep#quebec-school-system"
+                                <strong>are the Quebec Secondary School diploma requirements. See <a href="/quetudesinfo/whatiscegep#quebec-school-system"
                                         target="_blank">What is CEGEP — Quebec School System</a> for more information.</strong></p>
                             <p class="tool-disclaimer"><i class="fas fa-info-circle"></i> The Program Comparison Tool was first created in August
                                 2021 and only has data for pre-university programs at 8
-                                colleges, but you can find the CEGEP viewbooks, where technical programs are presented in detail, at <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">Important Links</a>.
+                                colleges, but you can find the CEGEP viewbooks, where technical programs are presented in detail, at <a href="/quetudesinfo/links" target="_blank">Important Links</a>.
                                 <strong><u>The official sites and documents should always be consulted for the most accurate and up-to-date information.</u></strong>
                             </p>
 
@@ -399,7 +399,7 @@
                     comprehensive assessments, one for each
                     program/discipline of the
                     double DEC. Consult official websites, viewbooks, and/or brochures for details.</p>
-                <p class="sources">Sources: <a href="https://cw118.github.io/quetudesinfo/links">official CEGEP websites, viewbooks, program brochures and more</a>
+                <p class="sources">Sources: <a href="/quetudesinfo/links">official CEGEP websites, viewbooks, program brochures and more</a>
                 </p>
             </div>
 
@@ -413,23 +413,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/contact.html
+++ b/contact.html
@@ -47,50 +47,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -112,23 +112,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/help.html
+++ b/help.html
@@ -48,50 +48,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -113,19 +113,19 @@
                 <div id="cegep-desc" class="collapse mt-2">
                     <p>CEGEP is the acronym for Quebec's <em>Collège d'enseignement général et professionnel</em>, a type of post-secondary institution
                     specific to the province. CEGEPs are meant to help students transition from high school to university or the workforce.</p>
-                    <p class="text-roboto-condensed"><em>Read more at <a href="https://cw118.github.io/quetudesinfo/whatiscegep" target="_blank">What is CEGEP</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more at <a href="/quetudesinfo/whatiscegep" target="_blank">What is CEGEP</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#des-dss" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="des-dss">What is a DES/DSS?</a>
                 <div id="des-dss" class="collapse mt-2">
                     <p>A DES = <em>Diplôme d'études secondaires</em>. It's the French abbreviation for the Quebec high school diploma and is identical to the DSS.</p>
                     <p>A DES = Diploma of Secondary Studies. It's the English abbreviation for the Quebec high school diploma and is identical to the DES.</p>
-                    <p class="text-roboto-condensed"><em>Read more about Quebec's high school diploma at <a href="https://cw118.github.io/quetudesinfo/whatiscegep#quebec-school-system" target="_blank">What is CEGEP — Quebec's School System</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about Quebec's high school diploma at <a href="/quetudesinfo/whatiscegep#quebec-school-system" target="_blank">What is CEGEP — Quebec's School System</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#dec-dcs" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="dec-dcs">What is a DEC/DCS?</a>
                 <div id="dec-dcs" class="collapse mt-2">
                     <p>A DEC = <em>Diplôme d'études collégiales</em>. It's the French acronym for a Quebec CEGEP/college diploma and is identical to the DCS.</p>
                     <p>A DCS = Diploma of Collegial Studies. It's the English abbreviation for a Quebec CEGEP/college diploma and is identical to the DEC.</p>
-                    <p class="text-roboto-condensed"><em>Read more about Quebec CEGEP/college diploma at <a href="https://cw118.github.io/quetudesinfo/whatiscegep#dcs" target="_blank">What is CEGEP — Diploma of Collegial Studies</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about Quebec CEGEP/college diploma at <a href="/quetudesinfo/whatiscegep#dcs" target="_blank">What is CEGEP — Diploma of Collegial Studies</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#r-score" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="r-score">What's an R-Score?</a>
                 <div id="r-score" class="collapse mt-2">
@@ -133,7 +133,7 @@
                     a student's rank in their group: calculations take into account not only your academic performance in a college course,
                     but also group strength (academic strength and performance of your classmates), allowing Quebec universities to better
                     compare applicants for admissions purposes even if applicants attended different CEGEPs.</p>
-                    <p class="text-roboto-condensed"><em>Read more about R-Scores at <a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score" target="_blank">The R-Score</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about R-Scores at <a href="/quetudesinfo/whatiscegep/r-score" target="_blank">The R-Score</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#day-div" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="day-div">What does Day Division/daytime sector mean?</a>
                 <div id="day-div" class="collapse mt-2">
@@ -153,7 +153,7 @@
                     <p>CEGEPs look at all of your secondary 4 and 5 grades. Core subjects, which are those with ministerial exams such as
                     secondary 5 English and French, are usually given more importance. Multiple averages are also calculated—depending on
                     the program, an overall average, math/science average, social science average, etc. will be taken into account.</p>
-                    <p class="text-roboto-condensed"><em>Read more about CEGEP admissions at <a href="https://cw118.github.io/quetudesinfo/apply#admissions" target="_blank">Applying to CEGEP — Admissions: Evaluating applicants</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about CEGEP admissions at <a href="/quetudesinfo/apply#admissions" target="_blank">Applying to CEGEP — Admissions: Evaluating applicants</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#cegep-admissions-eca" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="cegep-admissions-eca">Do CEGEPs look at my extracurriculars, CV, etc.?</a>
                 <div id="cegep-admissions-eca" class="collapse mt-2">
@@ -161,7 +161,7 @@
                     applying for a scholarship/bursary (many require a letter of intent and/or your curriculum vitae), where you may mention
                     extracurricular activities and other non scholastic experiences. <em>Some colleges allow students to submit an explanatory
                     letter if they feel that their academic record is not a true indication of their ability.</em></p>
-                    <p class="text-roboto-condensed"><em>Read more about CEGEP admissions at <a href="https://cw118.github.io/quetudesinfo/apply#admissions" target="_blank">Applying to CEGEP — Admissions: Evaluating applicants</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about CEGEP admissions at <a href="/quetudesinfo/apply#admissions" target="_blank">Applying to CEGEP — Admissions: Evaluating applicants</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#prereq-cutoffs" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="prereq-cutoffs">What are program prerequisites and cutoffs?</a>
                 <div id="prereq-cutoffs" class="collapse mt-2">
@@ -171,7 +171,7 @@
                     <p>Cutoffs are the minimum grades required in order to be eligible for admission to a program. For example, students
                     applying to John Abbott's Enriched Science program must minimally have an 85% overall average, as well as a grade of 80%
                     in each science and math prerequisite course.</p>
-                    <p class="text-roboto-condensed"><em>Read more about program prerequisites, cutoffs and additional requirements at <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program#factors-program" target="_blank">Choosing a CEGEP and Program — Factors to consider: Program</a>. You may also like our <a href="compare-programs.html" target="_blank">Program Comparison Tool</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about program prerequisites, cutoffs and additional requirements at <a href="/quetudesinfo/apply/choose-a-cegep-program#factors-program" target="_blank">Choosing a CEGEP and Program — Factors to consider: Program</a>. You may also like our <a href="compare-programs.html" target="_blank">Program Comparison Tool</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#conditional-acceptance" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="conditional-acceptance">What does "conditional acceptance" mean?</a>
                 <div id="conditional-acceptance" class="collapse mt-2">
@@ -179,14 +179,14 @@
                     acceptance simply means that in order to keep your spot at a CEGEP, you must still meet program requirements at the end
                     of the year (they will check your final results), including a secondary school diploma and all prerequisite courses with
                     appropriate grades.</p>
-                    <p class="text-roboto-condensed"><em>Read more about CEGEP Admissions at <a href="https://cw118.github.io/quetudesinfo/apply" target="_blank">Applying to CEGEP</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about CEGEP Admissions at <a href="/quetudesinfo/apply" target="_blank">Applying to CEGEP</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#quebec-student" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="quebec-student">Am I considered/Do I apply as a Quebec student?</a>
                 <div id="quebec-student" class="collapse mt-2">
                     <p>As long as you are studying in a Quebec high school when you submit your applications, yes, you're considered a Quebec
                     student. Note that qualifying as a Quebec student does not necessarily mean you qualify as a Quebec resident—see the
                     following question in the <a href="#misc">Miscellaneous section</a> for clarification: <em>For immigrants/temporary residents: am I considered a Quebec resident by colleges?</em></p>
-                    <p class="text-roboto-condensed"><em>Read more about the types of students and CEGEP applications at <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about the types of students and CEGEP applications at <a href="/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
                 </div>
 
                 <h3 class="yellow-bg mt-3 mb-3">CEGEP Applications</h3>
@@ -196,7 +196,7 @@
                     corresponding official application system—each CEGEP uses their own, except SRAM-affiliated CEGEPs, which use the SRAM
                     application system. Once you've logged in and begun an application, follow the instructions displayed to complete and
                     submit it.</p>
-                    <p class="text-roboto-condensed"><em>Learn more about application systems and how to apply at <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Learn more about application systems and how to apply at <a href="/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#when-to-apply" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="when-to-apply">When do I apply?</a>
                 <div id="when-to-apply" class="collapse mt-2">
@@ -204,41 +204,41 @@
                     modules/systems open in mid-January and the deadline is March 1.</p>
                     <p>The Winter semester is mostly for CEGEP transfer students and adults in Continuing Education; application modules
                     typically open at the end of September and the deadline is November 1.</p>
-                    <p class="text-roboto-condensed"><em>Learn more about CEGEP applications at <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>, or see some dates to remember at <a href="important-dates.html" target="_blank">Important Dates</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Learn more about CEGEP applications at <a href="/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>, or see some dates to remember at <a href="important-dates.html" target="_blank">Important Dates</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#apply-documents" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="apply-documents">What documents do I need to apply?</a>
                 <div id="apply-documents" class="collapse mt-2">
                     <p>The documents you're required to submit or send vary with each CEGEP and your situation. Depending on your status in
                     Canada and your school, you may need to submit your birth certificate, certain report cards, immigration documents and
                     the like. Be sure to have a credit card on hand if you're paying application fees online.</p>
-                    <p class="text-roboto-condensed"><em>Find out more about required documents for CEGEP applications at <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Find out more about required documents for CEGEP applications at <a href="/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#apply-how-many" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="apply-how-many">How many CEGEPs should I apply to?</a>
                 <div id="apply-how-many" class="collapse mt-2">
                     <p>Apply to multiple CEGEPs! Admissions can be quite competitive depending on the program you apply to; nevertheless, CEGEP
                     is a key stage of education for students, so it's best to play it safe.</p>
-                    <p class="text-roboto-condensed"><em>Read more about making smart choices when applying to CEGEP at <a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices" target="_blank">Making smart choices</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about making smart choices when applying to CEGEP at <a href="/quetudesinfo/apply/make-smart-choices" target="_blank">Making smart choices</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#whats-sram" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="whats-sram">What is SRAM?</a>
                 <div id="whats-sram" class="collapse mt-2">
                     <p>SRAM is the <em>Service régional d'admission du Montréal métropolitain</em>, an organization affiliated with many public French
                     and English CEGEPs. SRAM was founded in an effort to better regulate CEGEP admissions and developed a unique round
                     system for their applications to prevent applicants from hoarding spots.</p>
-                    <p class="text-roboto-condensed"><em>Read more about how SRAM evaluates applicants at <a href="https://cw118.github.io/quetudesinfo/apply#admissions" target="_blank">Applying to CEGEP — Admissions: Evaluating Applicants</a>, or find out how to apply to certain CEGEPs through SRAM at <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about how SRAM evaluates applicants at <a href="/quetudesinfo/apply#admissions" target="_blank">Applying to CEGEP — Admissions: Evaluating Applicants</a>, or find out how to apply to certain CEGEPs through SRAM at <a href="/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#sram-affiliated" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="sram-affiliated">What are SRAM-affiliated CEGEPs?</a>
                 <div id="sram-affiliated" class="collapse mt-2">
                     <p>As stated in the name, SRAM-affiliated CEGEPs are colleges that are part of SRAM and that use their application system.
                     The following English-language CEGEPs are affiliated with SRAM: Vanier College, John Abbott College, Champlain College
                     Lennoxville, Heritage College.</p>
-                    <p class="text-roboto-condensed"><em>Read more about how SRAM evaluates applicants at <a href="https://cw118.github.io/quetudesinfo/apply#admissions" target="_blank">Applying to CEGEP — Admissions: Evaluating Applicants</a>, or find out more about SRAM's application system at <a href="https://cw118.github.io/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about how SRAM evaluates applicants at <a href="/quetudesinfo/apply#admissions" target="_blank">Applying to CEGEP — Admissions: Evaluating Applicants</a>, or find out more about SRAM's application system at <a href="/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#after-applying" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="after-applying">What do I do after applying?</a>
                 <div id="after-applying" class="collapse mt-2">
                     <p>Congrats on submitting your applications! The main thing to do now is to wait for your results—check your application
                     status periodically once CEGEPs start sending out responses. Once you've been admitted to the CEGEP you want to attend,
                     confirm your acceptance at that, and ONLY that particular CEGEP (don't hoard spots!).</p>
-                    <p class="text-roboto-condensed"><em>Learn more at <a href="https://cw118.github.io/quetudesinfo/apply/after-applying" target="_blank">After applying</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Learn more at <a href="/quetudesinfo/apply/after-applying" target="_blank">After applying</a>.</em></p>
                 </div>
 
                 <h3 class="yellow-bg mt-3 mb-3">CEGEP Programs</h3>
@@ -247,18 +247,18 @@
                     <p>CEGEP offers a wide selection of programs, though the options available vary with every college. Programs are
                     categorized into two types, pre-university and career/technical programs <em>(see "What's the difference between a two-year
                     and a three-year program?")</em>, and cover numerous disciplines ranging from arts and humanities to the sciences.</p>
-                    <p class="text-roboto-condensed"><em>Read more about CEGEP programs at <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs" target="_blank">Programs</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about CEGEP programs at <a href="/quetudesinfo/whatiscegep/programs" target="_blank">Programs</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#post-secondary" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="post-secondary">Is CEGEP the only post-secondary option in Quebec?</a>
                 <div id="post-secondary" class="collapse mt-2">
                     <p>No, though it is the most common option in Quebec. Some students choose vocational training programs, or choose to
                     transition to university after a special Grade 12 program or after one year of CEGEP.</p>
-                    <p class="text-roboto-condensed"><em>Read more about post-secondary alternatives at <a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives" target="_blank">Alternatives to CEGEP</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about post-secondary alternatives at <a href="/quetudesinfo/whatiscegep/cegep-alternatives" target="_blank">Alternatives to CEGEP</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#cegep-uni" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="cegep-uni">Do I have to go to CEGEP before going to university?</a>
                 <div id="cegep-uni" class="collapse mt-2">
                     <p>In general for Quebec students, yes.</p>
-                    <p class="text-roboto-condensed"><em>Read more about CEGEP and Quebec's education system at <a href="https://cw118.github.io/quetudesinfo/whatiscegep" target="_blank">What is CEGEP</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about CEGEP and Quebec's education system at <a href="/quetudesinfo/whatiscegep" target="_blank">What is CEGEP</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#two-vs-threeyear" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="two-vs-threeyear">What's the difference between a two-year program and a three-year program?</a>
                 <div id="two-vs-threeyear" class="collapse mt-2">
@@ -269,14 +269,14 @@
                     <p>Technical programs <em>(also called career programs)</em> are three-year programs designed to integrate students into the
                     workforce directly after graduation. They provide technical training, offering specialized courses that concentrate on
                     the chosen field.</p>
-                    <p class="text-roboto-condensed"><em>Read more about program types and names at <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs" target="_blank">Programs</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about program types and names at <a href="/quetudesinfo/whatiscegep/programs" target="_blank">Programs</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#best-fit" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="best-fit">What's the best CEGEP/program?</a>
                 <div id="best-fit" class="collapse mt-2">
                     <p>No CEGEP or program is one-size-fits-all, and because of this, there really is no answer to this question. Everyone has
                     different interests, skills, values, and learning preferences—knowing yourself well is key to finding the college and
                     program that's the best fit for you.</p>
-                    <p class="text-roboto-condensed"><em>See the two questions directly below, or read more at <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program" target="_blank">Choosing a CEGEP and Program</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>See the two questions directly below, or read more at <a href="/quetudesinfo/apply/choose-a-cegep-program" target="_blank">Choosing a CEGEP and Program</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#choose-cegep" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="choose-cegep">How do I choose a CEGEP?</a>
                 <div id="choose-cegep" class="collapse mt-2">
@@ -284,7 +284,7 @@
                     options and extracurriculars are among some of them.</p>
                     <p>It's a good idea to visit the CEGEPs during open houses, sit in on classes with Student-for-a-Day, meet with your
                     guidance counsellor and to consult college websites and viewbooks. (Remember to apply to multiple CEGEPs!)</p>
-                    <p class="text-roboto-condensed"><em>Read more at <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program" target="_blank">Choosing a CEGEP and Program</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more at <a href="/quetudesinfo/apply/choose-a-cegep-program" target="_blank">Choosing a CEGEP and Program</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#choose-program" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="choose-program">How do I choose a program?</a>
                 <div id="choose-program" class="collapse mt-2">
@@ -293,7 +293,7 @@
                     before applying!</p>
                     <p>Other things to factor into your decision include the program type (pre-university/technical) and your interests—the
                     best fit for you is a program that aligns with your traits and likes.</p>
-                    <p class="text-roboto-condensed"><em>Read more about choosing a program at <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program#factors-program" target="_blank">Choosing a CEGEP and Program — Factors to consider: Program</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about choosing a program at <a href="/quetudesinfo/apply/choose-a-cegep-program#factors-program" target="_blank">Choosing a CEGEP and Program — Factors to consider: Program</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#program-vs-profile" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="program-vs-profile">What's the difference between a program and a profile?</a>
                 <div id="program-vs-profile" class="collapse mt-2">
@@ -304,7 +304,7 @@
                     <p>For example, the Social Science program has numerous profiles like Psychology, General Social Science, Commerce, and
                     Child Studies—and since they're all part of the Social Science program, students in any of these profiles will graduate
                     with a DCS in Social Science.</p>
-                    <p class="text-roboto-condensed"><em>Read more about CEGEP programs and profiles at <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs#program-overview" target="_blank">Programs — Program Overview</a>.</em></p>
+                    <p class="text-roboto-condensed"><em>Read more about CEGEP programs and profiles at <a href="/quetudesinfo/whatiscegep/programs#program-overview" target="_blank">Programs — Program Overview</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#pa-health-science" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="pa-health-science">What's the difference between Pure & Applied Science and Health Science?</a>
                 <div id="pa-health-science" class="collapse mt-2">
@@ -312,7 +312,7 @@
                     Applied Science requires students to take 3 math, 3 physics, 1 biology and 2 chemistry courses, and students also have 2
                     elective courses. Health Science requires students to take 3 math, 3 physics, 2 biology and 3 chemistry courses.</p>
                     <p class="text-roboto-condensed"><em>Wondering how various pre-university programs are different from one another? Want more details on the differences
-                    between these two science profiles? Try our <a href="https://cw118.github.io/quetudesinfo/compare-programs" target="_blank">Program Comparison Tool</a>!</em></p>
+                    between these two science profiles? Try our <a href="/quetudesinfo/compare-programs" target="_blank">Program Comparison Tool</a>!</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#honours" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="honours">What are the benefits of an Honours program?</a>
                 <div id="honours" class="collapse mt-2">
@@ -329,7 +329,7 @@
                 <div id="official-sites" class="collapse mt-2">
                     <p>Generally, looking up the CEGEP or organization name in a search engine and selecting one of the first results will do.
                     QUÉtudes-info has also compiled a list of important links and documents at <em>Important Links</em> that you may find helpful.</p>
-                    <p><em>Find official college and organization sites and more at <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
+                    <p><em>Find official college and organization sites and more at <a href="/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#can-int-students" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="can-int-students">Does the information on QUÉtudes-info apply to all students, ie. out-of-province and international students?</a>
                 <div id="can-int-students" class="collapse mt-2">
@@ -337,14 +337,14 @@
                     equivalency charts to determine whether they are admissible to a program, since provinces have different education
                     systems. Moreover, certain CEGEP programs aren't available to international students, who must obtain an attestation of
                     academic equivalency in order to be admissible to CEGEP.</p>
-                    <p><em>For more information, consult official websites: <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
+                    <p><em>For more information, consult official websites: <a href="/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#finances" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="finances">Where can I find information on finances (tuition, financial aid, etc.)?</a>
                 <div id="finances" class="collapse mt-2">
                     <p>As QUÉtudes-info does not have any information on CEGEP finances, you'll need to visit the official college sites. If
                     you hold a temporary visa and are unsure whether you're required to pay a non-Quebec resident fee for CEGEP, see the
                     question directly below and/or consult the <em><a href="https://www.dawsoncollege.qc.ca/public/services/finance_department/quebecresidenceformenglish.pdf" target="_blank">Attestation of Québec Resident Status form</a></em>.</p>
-                    <p><em>Find important links such as official sites and documents at <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
+                    <p><em>Find important links such as official sites and documents at <a href="/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#quebec-resident" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="quebec-resident">For immigrants/temporary residents: am I considered a Quebec resident by colleges?</a>
                 <div id="quebec-resident" class="collapse mt-2">
@@ -354,14 +354,14 @@
                     <p>Secondly, there are 14 situations in which you may qualify as a Quebec resident. If you claim Quebec resident status and
                     have it recognized by your CEGEP, you will be exempt from any non-Quebec resident fees. See Part B of the <em>Attestation of Québec Resident Status form</em> here to verify your status: <a href="https://www.dawsoncollege.qc.ca/public/services/finance_department/quebecresidenceformenglish.pdf"
                         target="_blank">https://www.dawsoncollege.qc.ca/public/services/finance_department/quebecresidenceformenglish.pdf</a>.</p>
-                    <p><em>Also see official college websites for more information on student fees: <a href="https://cw118.github.io/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
+                    <p><em>Also see official college websites for more information on student fees: <a href="/quetudesinfo/links" target="_blank">Important Links</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#site-secure" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="site-secure">Is the QUÉtudes-info site safe?</a>
                 <div id="site-secure" class="collapse mt-2">
                     <p>Yes. Our site is secured with HTTPS (Hypertext Transfer Protocol Secure) and uses a safe subdomain, github.io, which is
                     inherited from the GitHub Pages website hosting service. (GitHub is a web-based repository-hosting service used by
                     developers all around the globe for easy collaboration and version control.)</p>
-                    <p><em>Read more about the QUÉtudes-info site and project at <a href="https://cw118.github.io/quetudesinfo/about/about-project" target="_blank">QUÉtudes-info: The Project</a>.</em></p>
+                    <p><em>Read more about the QUÉtudes-info site and project at <a href="/quetudesinfo/about/about-project" target="_blank">QUÉtudes-info: The Project</a>.</em></p>
                     <p><em>Learn more about GitHub at <a href="https://github.com/about" target="_blank">their About page</a>.</em></p>
                 </div>
                 <a class="btn lightgray-bg text-left w-100 mb-2" href="#site-issues" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="site-issues">Having issues with the site?</a>
@@ -386,35 +386,35 @@
                 <a class="btn btn-outline-dark mb-2" href="#sitemap-full" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="sitemap-full">Click here to show or hide the sitemap</a>
                 <div id="sitemap-full" class="collapse mt-2">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/" target="_blank">Home</a> <em>(Welcome! If you're not sure where to begin, the homepage suggests some starting points.)</em></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep" target="_blank">What is CEGEP</a> <em>(Overview of Quebec's education system and what CEGEP is.)</em>
+                        <li><a href="/quetudesinfo/" target="_blank">Home</a> <em>(Welcome! If you're not sure where to begin, the homepage suggests some starting points.)</em></li>
+                        <li><a href="/quetudesinfo/whatiscegep" target="_blank">What is CEGEP</a> <em>(Overview of Quebec's education system and what CEGEP is.)</em>
                             <ul class="inner">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs" target="_blank">Programs</a> <em>(In-depth explanations of important vocabulary and introduction to the basics of CEGEP programs.)</em></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps" target="_blank">English-language CEGEPs</a> <em>(Concise list and descriptions of CEGEPs offering English instruction.)</em></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score" target="_blank">The R-Score</a> <em>(Detailed dissection of CEGEP R-Scores, their purpose, and the R-Score formula.)</em></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives" target="_blank">Alternatives to CEGEP</a> <em>(Brief rundown of post-secondary alternatives.)</em></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs" target="_blank">Programs</a> <em>(In-depth explanations of important vocabulary and introduction to the basics of CEGEP programs.)</em></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps" target="_blank">English-language CEGEPs</a> <em>(Concise list and descriptions of CEGEPs offering English instruction.)</em></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score" target="_blank">The R-Score</a> <em>(Detailed dissection of CEGEP R-Scores, their purpose, and the R-Score formula.)</em></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives" target="_blank">Alternatives to CEGEP</a> <em>(Brief rundown of post-secondary alternatives.)</em></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply" target="_blank">Applying to CEGEP</a> <em>(Explanation of CEGEP admissions and introduction to CEGEP applications.)</em>
+                        <li><a href="/quetudesinfo/apply" target="_blank">Applying to CEGEP</a> <em>(Explanation of CEGEP admissions and introduction to CEGEP applications.)</em>
                             <ul class="inner">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program" target="_blank">Choosing a CEGEP and Program</a> <em>(Tips on choosing a CEGEP and program.)</em></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices" target="_blank">Making smart choices</a> <em>(Strategies and things to keep in mind for CEGEP applications.)</em></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates" target="_blank">Important Dates</a> <em>(Event calendar with dates to remember for CEGEP applicants.)</em></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a> <em>(Comprehensive guide to applying to CEGEP, with instructions specific to each application system.)</em></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying" target="_blank">After applying</a> <em>(What comes after submitting applications and clarification of CEGEP General Education requirements.)</em></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program" target="_blank">Choosing a CEGEP and Program</a> <em>(Tips on choosing a CEGEP and program.)</em></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices" target="_blank">Making smart choices</a> <em>(Strategies and things to keep in mind for CEGEP applications.)</em></li>
+                                <li><a href="/quetudesinfo/apply/important-dates" target="_blank">Important Dates</a> <em>(Event calendar with dates to remember for CEGEP applicants.)</em></li>
+                                <li><a href="/quetudesinfo/apply/application-systems" target="_blank">Application Systems</a> <em>(Comprehensive guide to applying to CEGEP, with instructions specific to each application system.)</em></li>
+                                <li><a href="/quetudesinfo/apply/after-applying" target="_blank">After applying</a> <em>(What comes after submitting applications and clarification of CEGEP General Education requirements.)</em></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs" target="_blank">Program Comparison Tool</a> <em>(Compare pre-university programs side-by-side with ease.)</em></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" target="_blank">Important Links</a> <em>(URLs for official websites and helpful resources on CEGEP.)</em></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" target="_blank">Resources</a> <em>(Free web resources for a variety of subjects.)</em></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms" target="_blank">About &#8594; Disclaimers and Terms</a> <em>(Important information including disclaimers, licenses and terms of use.)</em>
+                        <li><a href="/quetudesinfo/compare-programs" target="_blank">Program Comparison Tool</a> <em>(Compare pre-university programs side-by-side with ease.)</em></li>
+                        <li><a href="/quetudesinfo/links" target="_blank">Important Links</a> <em>(URLs for official websites and helpful resources on CEGEP.)</em></li>
+                        <li><a href="/quetudesinfo/resources" target="_blank">Resources</a> <em>(Free web resources for a variety of subjects.)</em></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms" target="_blank">About &#8594; Disclaimers and Terms</a> <em>(Important information including disclaimers, licenses and terms of use.)</em>
                             <ul class="inner">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project" target="_blank">QUÉtudes-info: The Project</a> <em>(About the project, brief explanation of why and how this site was created.)</em></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me" target="_blank">About the site creator</a> <em>(About me, the student behind QUÉtudes-info.)</em></li>
+                                <li><a href="/quetudesinfo/about/about-project" target="_blank">QUÉtudes-info: The Project</a> <em>(About the project, brief explanation of why and how this site was created.)</em></li>
+                                <li><a href="/quetudesinfo/about/about-me" target="_blank">About the site creator</a> <em>(About me, the student behind QUÉtudes-info.)</em></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a> <em>(<strong>You are here</strong>: FAQ and sitemap)</em></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/contact" target="_blank">Contact</a> <em>(hopefully coming soon)</em></li>                        
+                        <li><a href="/quetudesinfo/help">Help</a> <em>(<strong>You are here</strong>: FAQ and sitemap)</em></li>
+                        <li><a href="/quetudesinfo/contact" target="_blank">Contact</a> <em>(hopefully coming soon)</em></li>                        
                     </ul>
                 </div>
 
@@ -428,23 +428,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -46,51 +46,51 @@
 
             <div id="header">
                 <div class="banner index-banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right index-rheader">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav index-topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a class="active" href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a class="active" href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -103,7 +103,7 @@
             </nav>
 
             <div class="custom-alert">
-                <span class="msg"><i class="fas fa-info-circle"></i> <strong>Disclaimer:</strong> QUÉtudes-info is <u>not</u> affiliated with any mentioned schools, organizations or institutions. This is <u><strong>not</strong> an official website</u>. For more information, please see <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers" class="alert-link">Disclaimers</a> and <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms" class="alert-link">Terms of Use</a>.</span>
+                <span class="msg"><i class="fas fa-info-circle"></i> <strong>Disclaimer:</strong> QUÉtudes-info is <u>not</u> affiliated with any mentioned schools, organizations or institutions. This is <u><strong>not</strong> an official website</u>. For more information, please see <a href="/quetudesinfo/about/disclaimers-terms#disclaimers" class="alert-link">Disclaimers</a> and <a href="/quetudesinfo/about/disclaimers-terms#terms" class="alert-link">Terms of Use</a>.</span>
                 <span class="close-btn">
                     <i class="fas fa-times"></i>
                 </span>
@@ -111,9 +111,9 @@
             
             <h1 id="welcome-title" class="custom-container"><i class="fas fa-graduation-cap"></i> Welcome to QUÉtudes-info!</h1>
             <div class="custom-container" id="home-description">
-                <div><p id="index-about-me"><i class="fas fa-users"></i> <strong>A student-run website for parents, students and anyone curious to learn about CEGEP.</strong><br><em><a href="https://cw118.github.io/quetudesinfo/about/about-me">Read about the site creator here.</a></em></p><br></div>
+                <div><p id="index-about-me"><i class="fas fa-users"></i> <strong>A student-run website for parents, students and anyone curious to learn about CEGEP.</strong><br><em><a href="/quetudesinfo/about/about-me">Read about the site creator here.</a></em></p><br></div>
                 <div class="clearfix"><p id="index-about-project"><strong>An overview of Quebec's school system, CEGEPs, CEGEP admissions and applications —
-                        all in one place.</strong><br><em><a href="https://cw118.github.io/quetudesinfo/about/about-project">Find out more about the QUÉtudes-info project.</a></em></p></div>
+                        all in one place.</strong><br><em><a href="/quetudesinfo/about/about-project">Find out more about the QUÉtudes-info project.</a></em></p></div>
             </div>
 
             <div id="get-started">
@@ -127,7 +127,7 @@
                     <div class="overlay">
                         <div class="citation">Photo by Rich Martello on Unsplash, 80% opacity</div>
                         <div class="custom-card-title">Not sure what CEGEP is, or what CEGEPs are out there?</div>
-                        <div class="card-button"><a class="btn btn-light" href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a></div>
+                        <div class="card-button"><a class="btn btn-light" href="/quetudesinfo/whatiscegep">What is CEGEP</a></div>
                     </div>                        
                 </div>
                 <div class="card-item text-center">
@@ -135,7 +135,7 @@
                     <div class="overlay">
                         <div class="citation">Photo by Jean Gagnon, CC 3.0 licence, 80% opacity</div>
                         <div class="custom-card-title">Want to know more about CEGEP admissions and applications?</div>
-                        <div class="card-button"><a class="btn btn-light" href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP</a>
+                        <div class="card-button"><a class="btn btn-light" href="/quetudesinfo/apply">Applying to CEGEP</a>
                         </div>
                     </div>
                 </div>
@@ -145,7 +145,7 @@
                     <div class="overlay">
                         <div class="citation">Photo by Talha Hassan on Unsplash, 80% opacity</div>
                         <div class="custom-card-title">Unsure about the differences between some CEGEP programs?</div>
-                        <div class="card-button"><a class="btn btn-light" href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a>
+                        <div class="card-button"><a class="btn btn-light" href="/quetudesinfo/compare-programs">Program Comparison Tool</a>
                         </div>
                         <small>*Only pre-university programs can be compared</small>
                     </div>
@@ -156,7 +156,7 @@
                     <div class="overlay">
                         <div class="citation">Photo by J. Paxon Reyes, CC BY-NC 2.0 licence, 80% opacity</div>
                         <div class="custom-card-title">Already know about CEGEP and looking for the official sites?</div>
-                        <div class="card-button"><a class="btn btn-light" href="https://cw118.github.io/quetudesinfo/links">Important Links</a>
+                        <div class="card-button"><a class="btn btn-light" href="/quetudesinfo/links">Important Links</a>
                         </div>
                     </div>
                 </div>
@@ -184,7 +184,7 @@
             </div>
 
             <div id="dates-important">
-                <h1><a href="https://cw118.github.io/quetudesinfo/apply/important-dates"><i class="fas fa-calendar-week"></i> DATES TO REMEMBER</a></h1>
+                <h1><a href="/quetudesinfo/apply/important-dates"><i class="fas fa-calendar-week"></i> DATES TO REMEMBER</a></h1>
                 <div class="events">
                     <div class="event clearfix">
                         <div class="time">
@@ -229,7 +229,7 @@
                 <div class="hero-text">
                     <h3>Looking for homework help, tutorials, or want to learn something new?</h3>
                     <p>Check out these</p>
-                    <a class="btn btn-outline-light" href="https://cw118.github.io/quetudesinfo/resources">Web Resources</a>
+                    <a class="btn btn-outline-light" href="/quetudesinfo/resources">Web Resources</a>
                 </div>
                 <div class="hero-footer">
                     <p class="text-muted">Photo by Freddie Marriage on Unsplash</p>
@@ -241,23 +241,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/links.html
+++ b/links.html
@@ -48,50 +48,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" class="active" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" class="active" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -259,23 +259,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/resources.html
+++ b/resources.html
@@ -48,50 +48,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" class="active" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" class="active" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -285,7 +285,7 @@
                             </div>
                         </div>
                     </div>
-                    <br><p class="text-center bg-light border-dark text-dark banner-bottom w-75">Looking for CEGEP-related sites? <a href="https://cw118.github.io/quetudesinfo/links" class="btn btn-dark mt-1">Important Links</a></p><br>
+                    <br><p class="text-center bg-light border-dark text-dark banner-bottom w-75">Looking for CEGEP-related sites? <a href="/quetudesinfo/links" class="btn btn-dark mt-1">Important Links</a></p><br>
                 </div>
 
                 <div class="pagination mt-3 mb-2" role="navigation">
@@ -299,23 +299,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/whatiscegep/cegep-alternatives.html
+++ b/whatiscegep/cegep-alternatives.html
@@ -47,50 +47,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="active">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep" class="active">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -110,17 +110,17 @@
                 <a class="nav-link" href="#grade12">Grade 12 Program</a>
                 <hr>
                 <p class="sidenav-title">In this section</p>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a>
-                <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep">What is CEGEP</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/programs">Programs</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/r-score">The R-Score</a>
+                <a class="nav-link active" href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
             </nav>
 
             <section>
                 <div class="pagination mb-2" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score" class="btn btn-warning previous">&#8592; Previous</a>
-                    <a href="https://cw118.github.io/quetudesinfo/apply" class="btn btn-info next">Next: Applying to CEGEP</a>
+                    <a href="/quetudesinfo/whatiscegep/r-score" class="btn btn-warning previous">&#8592; Previous</a>
+                    <a href="/quetudesinfo/apply" class="btn btn-info next">Next: Applying to CEGEP</a>
                 </div>
                 <h2 class="lightblue-bg" id="cegep-alternatives">Alternatives to CEGEP</h2>
                 <p>Quebec's education system offers many options when it comes to study programs. There isn't, unfortunately, a single list
@@ -216,9 +216,9 @@
                 <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
 
                 <div class="pagination" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score" class="btn btn-warning previous">&#8592; Previous</a>
+                    <a href="/quetudesinfo/whatiscegep/r-score" class="btn btn-warning previous">&#8592; Previous</a>
                     <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                    <a href="https://cw118.github.io/quetudesinfo/apply" class="btn btn-info next">Next: Applying to CEGEP</a>
+                    <a href="/quetudesinfo/apply" class="btn btn-info next">Next: Applying to CEGEP</a>
                 </div>
 
             </section>
@@ -228,23 +228,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/whatiscegep/english-cegeps.html
+++ b/whatiscegep/english-cegeps.html
@@ -46,49 +46,49 @@
                 
                 <div id="header">
                     <div class="banner">
-                        <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
+                        <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                     </div>
                     <div class="header-right">
-                        <a id="header-help" href="helphttps://cw118.github.io/quetudesinfo/">Help</a>
-                        <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                        <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                        <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                        <a id="header-help" href="/quetudesinfo/help">Help</a>
+                        <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                        <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                        <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                     </div>
                 </div>   
                 
                 <nav class="topnav">
                     <div id="topnav-end">
                         <ul class="nav-links">
-                            <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                            <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="active">What is CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/whatiscegep" class="active">What is CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown1">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                    <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                                 </ul>
                             </li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                                <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown2">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                    <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                    <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                    <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                    <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                    <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                                 </ul>
                             </li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                             <li>
-                                <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                                <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                                 <ul class="dropdown" id="nav-dropdown3">
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                    <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                    <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                    <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                    <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                                 </ul>
                             </li>
                         </ul>
@@ -108,17 +108,17 @@
                     <a class="nav-link" href="#bilingual-colleges">Bilingual colleges</a>
                     <hr>
                     <p class="sidenav-title">In this section</p>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>
-                    <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a>
-                    <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
+                    <a class="nav-link" href="/quetudesinfo/whatiscegep">What is CEGEP</a>
+                    <a class="nav-link" href="/quetudesinfo/whatiscegep/programs">Programs</a>
+                    <a class="nav-link active" href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>
+                    <a class="nav-link" href="/quetudesinfo/whatiscegep/r-score">The R-Score</a>
+                    <a class="nav-link" href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
                 </nav>
         
                 <section>
                     <div class="pagination mb-2" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs" class="btn btn-warning previous">&#8592; Previous</a>
-                        <a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score" class="btn btn-warning next">Next &#8594;</a>
+                        <a href="/quetudesinfo/whatiscegep/programs" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/whatiscegep/r-score" class="btn btn-warning next">Next &#8594;</a>
                     </div>
                     <h2 id="eng-cegeps" class="lightblue-bg">English-language CEGEPs</h2>
                     <p>In Quebec, there are a total of 9 colleges that offer English instruction and specialize in DEC programs. A DEC program
@@ -137,7 +137,7 @@
                     </ul>
                     <p>CEGEP/college diplomas refer to DCS/DEC; vocational/trade school diplomas tend to refer to DEP/DVS. When researching and applying to CEGEPs, make sure you choose programs that lead to a DCS/DEC!</p>
                     <p><em>When referring to a program by its diploma type, the French acronyms are typically used.</em></p>
-                    <p><i class="fas fa-info-circle"></i> To learn more about special programs and opportunities like Springboard to a DCS, field trips and exchanges, see <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs#special-programs">Special Programs</a>, and <strong>visit <a href="https://cw118.github.io/quetudesinfo/links">official college sites</a> for details</strong>.</p>
+                    <p><i class="fas fa-info-circle"></i> To learn more about special programs and opportunities like Springboard to a DCS, field trips and exchanges, see <a href="/quetudesinfo/whatiscegep/programs#special-programs">Special Programs</a>, and <strong>visit <a href="/quetudesinfo/links">official college sites</a> for details</strong>.</p>
 
                     <h2 class="yellow-bg" id="big-five">The <em>&#8220;Big Five&#8221;</em></h2>
                     <p>Listed here are the five most <strong>well-known</strong> English CEGEPs, especially to students in Montreal.</p>
@@ -153,7 +153,7 @@
                             <p class="caption">Photo by Colocho, CC BY-SA 3.0 licence.</p>
                         </div>
                         <ul>
-                            <li>Private English college: only offers <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">pre-university programs</a></li>
+                            <li>Private English college: only offers <a href="/quetudesinfo/whatiscegep/programs">pre-university programs</a></li>
                             <li>Location: Westmount, Quebec</li>
                             <li>Founded in 1908 <em>(as a bilingual institution)</em></li>
                             <li>Director General: Christian Corno</li>
@@ -165,7 +165,7 @@
                     <p class="description-bottom">Marianopolis College, often affectionately referred to as "Mari", is located between the Vendôme and Villa-Maria (STM
                     orange line) metro stations. It has a close-knit student body of roughly 2000 students, over 100 student clubs, and
                     classes are 25% smaller than public colleges on average. Marianopolis offers 6 academic programs in Science, Social
-                    Science, Arts and Sciences, ALC (Arts, Literature and Communication), Liberal Arts, and Music; the college is also a partner of <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs#special-programs">Alliance Sport-Études</a>.</p>                        
+                    Science, Arts and Sciences, ALC (Arts, Literature and Communication), Liberal Arts, and Music; the college is also a partner of <a href="/quetudesinfo/whatiscegep/programs#special-programs">Alliance Sport-Études</a>.</p>                        
                     
                     <h3 id="dawson-about">Dawson College</h3>
                     <div class="about-grid">
@@ -208,7 +208,7 @@
                     </div>
                     <p class="description-bottom">Vanier College is named in honour of Canadian soldier, diplomat and former Governor General, Georges P. Vanier. The
                     college has a student body of over 6700 students and offers 6 pre-university programs in ALC, Liberal Arts, Music,
-                    Science, Social Science, and Computer Science and Mathematics; here are 14 technical programs available as well. Vanier is also a partner of <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs#special-programs">Alliance Sport-Études</a>.</p>
+                    Science, Social Science, and Computer Science and Mathematics; here are 14 technical programs available as well. Vanier is also a partner of <a href="/quetudesinfo/whatiscegep/programs#special-programs">Alliance Sport-Études</a>.</p>
 
                     <h3 id="champlain-about">Champlain Regional College</h3>
                     <div class="about-grid">
@@ -262,7 +262,7 @@
                     Abbott College's day division, which offers 6 pre-university programs in Arts and Sciences, ALC, Liberal Arts, Science,
                     Social Science, and Visual Arts (510.A0), as well as 12 technical programs.</p>
 
-                    <p class="sources">Sources: <a href="https://fedecegeps.ca/federation/a-propos/membres/">Fédération des cégeps</a>, <a href="https://cw118.github.io/quetudesinfo/links">official CEGEP sites, viewbooks and more</a></p>
+                    <p class="sources">Sources: <a href="https://fedecegeps.ca/federation/a-propos/membres/">Fédération des cégeps</a>, <a href="/quetudesinfo/links">official CEGEP sites, viewbooks and more</a></p>
 
                     <h2 class="lightblue-bg" id="more-eng-colleges">More English colleges</h2>
                     <h3>Heritage College, Gatineau</h3>
@@ -284,7 +284,7 @@
                     <p><strong>Website:</strong> <a href="https://college.centennial.qc.ca/" target="_blank">https://college.centennial.qc.ca/</a></p>
                     <p class="description-bottom">Centennial College is an independent private English CEGEP that offers a pre-university Social Science program with the
                     option of two profiles, General Social Science and Commerce.</p>
-                    <p class="sources">Sources: <a href="https://cw118.github.io/quetudesinfo/links">official CEGEP sites</a></p>
+                    <p class="sources">Sources: <a href="/quetudesinfo/links">official CEGEP sites</a></p>
 
                     <h2 class="yellow-bg" id="bilingual-colleges">Bilingual colleges</h2>
                     <p>Instead of a focus on DEC programs, some of the colleges below offer more DEP and/or AEC programs. (Not sure what DEC,
@@ -319,7 +319,7 @@
                         <li>Location: Montreal, Quebec</li>
                         <li>4 pre-university programs in ALC, Science, Social Science, Computer Science and Mathematics</li>
                         <li>2 technical programs: Early Childhood Education, Special Care Counselling</li>
-                        <li>Offers a Grade 12 Study Option program (see <a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>)</li>
+                        <li>Offers a Grade 12 Study Option program (see <a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>)</li>
                     </ul>
 
                     <h3>LaSalle College</h3>
@@ -343,7 +343,7 @@
                                 <li>Travel Tourism/Tourism Techniques (414.AC)</li>
                                 <li>Hotel Management Technique/Hotel Management (430.A0)</li>
                                 <li>Interior Design (570.E0)</li>
-                                <li>Fashion Design (<a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs#program-overview">common code of 571</a>)</li>
+                                <li>Fashion Design (<a href="/quetudesinfo/whatiscegep/programs#program-overview">common code of 571</a>)</li>
                             </ul>
                         </li>
                     </ul>
@@ -351,18 +351,18 @@
                     <p>There are still some colleges out there that offer a few DCS programs, but it's hard to give a full list. You can find a
                     list of all Quebec colleges (includes English, French, public and private) on the Quebec government website here: <a href="https://www.quebec.ca/en/education/cegep/studying/list-colleges" target="_blank">List of CEGEPs and Private Colleges in Quebec</a></p>
 
-                    <p class="sources">Sources: <a href="https://fedecegeps.ca/federation/a-propos/membres/">Fédération des cégeps</a>, <a href="https://cw118.github.io/quetudesinfo/links">official college sites</a></p>
+                    <p class="sources">Sources: <a href="https://fedecegeps.ca/federation/a-propos/membres/">Fédération des cégeps</a>, <a href="/quetudesinfo/links">official college sites</a></p>
                     <hr>
-                    <p><strong>Want to learn more about applying to CEGEP? </strong><a href="https://cw118.github.io/quetudesinfo/apply" class="btn btn-primary">Applying to CEGEP</a></p>
-                    <p><strong>Curious about the R-Score, what it is and how it works?</strong> Continue to <strong><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></strong>.</p>
-                    <p><strong>Think CEGEP might not be for you?</strong> Try <strong><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></strong>.</p>
+                    <p><strong>Want to learn more about applying to CEGEP? </strong><a href="/quetudesinfo/apply" class="btn btn-primary">Applying to CEGEP</a></p>
+                    <p><strong>Curious about the R-Score, what it is and how it works?</strong> Continue to <strong><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></strong>.</p>
+                    <p><strong>Think CEGEP might not be for you?</strong> Try <strong><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></strong>.</p>
 
                     <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
                     
                     <div class="pagination" role="navigation">
-                        <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs" class="btn btn-warning previous">&#8592; Previous</a>
+                        <a href="/quetudesinfo/whatiscegep/programs" class="btn btn-warning previous">&#8592; Previous</a>
                         <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                        <a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score" class="btn btn-warning next">Next &#8594;</a>
+                        <a href="/quetudesinfo/whatiscegep/r-score" class="btn btn-warning next">Next &#8594;</a>
                     </div>
         
                 </section>
@@ -372,23 +372,23 @@
                 <div class="footer-row">
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                            <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                            <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                            <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                            <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                            <li><a href="/quetudesinfo/links">Important Links</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">
                         <ul>
-                            <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                            <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                            <li><a href="/quetudesinfo/help">Help</a></li>
+                            <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                            <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                         </ul>
                     </div>
                 </div>

--- a/whatiscegep/index.html
+++ b/whatiscegep/index.html
@@ -48,50 +48,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
+                    <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy" id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="active">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep" class="active">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>
                                 </li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -111,17 +111,17 @@
                 <a class="nav-link" href="#studying-at-cegep">Studying at CEGEP</a>
                 <hr>
                 <p class="sidenav-title">In this section</p>
-                <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>                
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
+                <a class="nav-link active" href="/quetudesinfo/whatiscegep">What is CEGEP</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/programs">Programs</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>                
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/r-score">The R-Score</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
             </nav>
 
             <section>
                 <div class="pagination mb-2" role="navigation">
                     <a href="#" class="btn btn-warning previous hide">&#8592; Previous</a>
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/whatiscegep/programs" class="btn btn-warning next">Next &#8594;</a>
                 </div>
                 <h2 id="whats-cegep" class="lightblue-bg">What is CEGEP?</h2>
                 <p><strong>CEGEP</strong> <em>(also written as CÉGEP, cegep, cégep, etc.)</em>, short for <strong>"Collège d'enseignement général et professionnel"</strong>, is a
@@ -149,7 +149,7 @@
                     <li>Secondary V Ethics and Religious Culture or Physical Education and Health, 2 credits</li>
                 </ul>
                 <p>Notice that only credits and grades from Secondary IV and Secondary V are considered for your diploma, as is the case
-                with CEGEP applications. <em>*Please note that many CEGEP programs have prerequisites beyond a secondary school diploma. For more details, see <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>.</em></p>
+                with CEGEP applications. <em>*Please note that many CEGEP programs have prerequisites beyond a secondary school diploma. For more details, see <a href="/quetudesinfo/whatiscegep/programs">Programs</a>.</em></p>
                 
                 <p class="label">Quebec youth sector Achievement Record</p>
                 <img class="xsmall-img" src="../assets/achievement-record.png" alt="Quebec achievement record sample">
@@ -185,7 +185,7 @@
                 years) for CEGEP. Here's a diagram overview of the Quebec school system from <a href="https://www.cegepsquebec.ca/en/" target="_blank">Cégeps du Québec</a>:</p>
                 <img loading="lazy" class="small-img" src="https://www.cegepsquebec.ca/wp-content/uploads/2019/03/SCHEMA_EN.svg" alt="Diagram of Quebec School System">
                 <p class="citation">From "Quebec School System" by Cégeps du Québec. Copyright by Cégeps du Québec, 2019.</p>
-                <p>The type of college program you apply to will depend on several factors. CEGEP programs are explained in more depth later in <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>.</p>
+                <p>The type of college program you apply to will depend on several factors. CEGEP programs are explained in more depth later in <a href="/quetudesinfo/whatiscegep/programs">Programs</a>.</p>
 
                 <p class="sources">Sources: <a href="http://www.education.gouv.qc.ca/en/students/report-cards-transcripts-diplomas/achievement-record/">Quebec Ministry of Education</a>, various course outlines and student schedules</p>
                 
@@ -209,7 +209,7 @@
                 evaluation is specified by the individual programs; depending on the college and program, the Comprehensive Assessment could be a project or portfolio of some sort. College students should receive specifications for this assessment when it is time for them to begin and complete it.</p>
                 <p>Students will also follow a specific education pattern, completing various concentration courses as per their program
                 requirements. For example, Science students must take certain Physics, Chemistry and Biology courses that may not be
-                required of Arts students—more on this in the <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs section of the site</a>.</p>
+                required of Arts students—more on this in the <a href="/quetudesinfo/whatiscegep/programs">Programs section of the site</a>.</p>
                 <p>Furthermore, meeting these DCS requirements does not necessarily mean that a student will have satisfied conditions for
                 university admission. Students should verify university admission criteria with an academic advisor and/or online to
                 ensure they obtain all university prerequisites.</p><br>
@@ -240,7 +240,7 @@
                 <div class="pagination" role="navigation">
                     <a href="#" class="btn btn-warning previous hide">&#8592; Previous</a>
                     <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/whatiscegep/programs" class="btn btn-warning next">Next &#8594;</a>
                 </div>
 
             </section>
@@ -250,23 +250,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/whatiscegep/programs.html
+++ b/whatiscegep/programs.html
@@ -48,50 +48,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a class="active" href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
+                            <a class="active" href="/quetudesinfo/whatiscegep">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -112,17 +112,17 @@
                 <a class="nav-link" href="#special-programs">Special programs, partnerships, and opportunities</a>
                 <hr>
                 <p class="sidenav-title">In this section</p>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a>
-                <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep">What is CEGEP</a>
+                <a class="nav-link active" href="/quetudesinfo/whatiscegep/programs">Programs</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/r-score">The R-Score</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
             </nav>
 
             <section>
                 <div class="pagination mb-2" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="btn btn-warning previous">&#8592; Previous</a>
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/whatiscegep" class="btn btn-warning previous">&#8592; Previous</a>
+                    <a href="/quetudesinfo/whatiscegep/english-cegeps" class="btn btn-warning next">Next &#8594;</a>
                 </div>
                 <h2 id="programs" class="lightblue-bg">Programs</h2>
                 <p>In CEGEP, there are 90* English DCS/DEC programs available in total: 25 are pre-university programs and/or profiles
@@ -139,7 +139,7 @@
 
                 <h2 id="program-overview" class="yellow-bg">Program Overview</h2>
                 <p class="p-disclaimer"><i class="fas fa-info-circle"></i> For full lists of a college's programs and other opportunities, please visit their official site and/or check their
-                viewbook. For a directory of all CEGEP programs, try the site <a href="https://pygma.ca/" target="_blank">Pygma</a>. Links to college websites and documents can be found in <a href="https://cw118.github.io/quetudesinfo/links">Important Links</a>.</p>
+                viewbook. For a directory of all CEGEP programs, try the site <a href="https://pygma.ca/" target="_blank">Pygma</a>. Links to college websites and documents can be found in <a href="/quetudesinfo/links">Important Links</a>.</p>
                 <p><strong>Pre-university programs</strong> lead to a Diploma of College Studies (DCS) in the program that you study and prepare you for university undergraduate
                 studies. Most of these are four semesters (two years) long. <em>Some pre-university programs are three years in duration because they combine two areas of study (more on this in
                 Special programs).</em></p>
@@ -160,7 +160,7 @@
                     <li>34 to 35 1/3 credits in Liberal Arts</li>
                 </ul>
                 <p>What does this mean? If you take the Science, Computer Science and Mathematics, Music, or Visual Arts program, you must
-                obtain 32 credits specific to your program (<em>not sure what the program-specific component is? See <a href="https://cw118.github.io/quetudesinfo/whatiscegep#dcs">Diploma of Collegial Studies</a></em>). If you take a Social Science program/profile (see below), you must obtain 30 to 31 ⅓ program-specific credits; if you
+                obtain 32 credits specific to your program (<em>not sure what the program-specific component is? See <a href="/quetudesinfo/whatiscegep#dcs">Diploma of Collegial Studies</a></em>). If you take a Social Science program/profile (see below), you must obtain 30 to 31 ⅓ program-specific credits; if you
                 take the Arts, Literature and Communication program, it's 30 credits, and so on.</p>
                 <br><p><strong>Career and technical programs</strong> are usually three years in duration and also lead to a DCS. They provide technical training and are designed to
                 integrate students into the workforce. Sometimes these are simply referred to as career programs, technical programs, or
@@ -189,17 +189,17 @@
                 prerequisite is a <u>letter of intent</u>—a brief, focused essay (around 1 page) covering various topics such as why you're
                 interested in the program, why the college should consider you, your interests and passions, and your school and
                 community involvement.</p>
-                <p>The <a href="https://cw118.github.io/quetudesinfo/whatiscegep#quebec-school-system">general CEGEP entrance requirement</a> is a Quebec Secondary School Diploma (SSD), but most programs have additional prerequisites and <u>cutoff grades</u> listed as well.</p>
+                <p>The <a href="/quetudesinfo/whatiscegep#quebec-school-system">general CEGEP entrance requirement</a> is a Quebec Secondary School Diploma (SSD), but most programs have additional prerequisites and <u>cutoff grades</u> listed as well.</p>
                 <p>A cutoff grade is the lowest grade acceptable for applicants of a particular program. Cutoffs are often listed for math
                 courses (secondary IV and V math TS or SN). Common cutoff averages are overall average (average of grades in all
                 subjects), math average (average of all math grades), and science average (average of all math and science grades, also
                 called science/math average).</p>
                 <p>For example, the Science program at a CEGEP may set an overall average cutoff at 80%, meaning students who wish to apply to
                 the Science program at that college must have a minimum overall average of 80%.</p>
-                <p class="sources">Sources: <a href="http://www.education.gouv.qc.ca/en/contenus-communs/enseignement-superieur/college-education/">Quebec Ministry of Education</a>, <a href="https://www.cegepsquebec.ca/en/our-study-programs/study-program-types/technical-programs/">Cégeps du Québec</a>, <a href="https://cw118.github.io/quetudesinfo/links">various CEGEP sites</a></p>
+                <p class="sources">Sources: <a href="http://www.education.gouv.qc.ca/en/contenus-communs/enseignement-superieur/college-education/">Quebec Ministry of Education</a>, <a href="https://www.cegepsquebec.ca/en/our-study-programs/study-program-types/technical-programs/">Cégeps du Québec</a>, <a href="/quetudesinfo/links">various CEGEP sites</a></p>
 
                 <h2 id="pre-u-programs" class="lightblue-bg">Pre-University Programs</h2>
-                <p class="p-disclaimer"><i class="fas fa-info-circle"></i> Program and/or profile names and prerequisites may vary with different colleges. For cutoff grades, which are not listed here, <a href="https://cw118.github.io/quetudesinfo/links">see the college website and/or viewbook</a>. This is <u>not</u> a full list of programs.</p>
+                <p class="p-disclaimer"><i class="fas fa-info-circle"></i> Program and/or profile names and prerequisites may vary with different colleges. For cutoff grades, which are not listed here, <a href="/quetudesinfo/links">see the college website and/or viewbook</a>. This is <u>not</u> a full list of programs.</p>
                 
                 <h3 id="alc">Arts, Literature, and Communication (ALC) (300.M0)</h3>
                 <p class="description-top">Creativity, self-expression, and passion for the arts is what this program's all about. ALC gives you the chance to
@@ -339,8 +339,8 @@
                     <li>Benefits: a more enriched curriculum, more learning opportunities outside the classroom (such as seminars and field trips)</li>
                 </ul>
                 <p><em>*Please see official websites and/or contact the colleges for specific details.</em></p>
-                <p>This is a very general and incomplete list meant to give you an idea of what kinds of programs CEGEPs may offer. For a bit more information on this site, try <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>. <strong>For full details on a CEGEP and their prorams, <a href="links.html">visit their official site and/or see their viewbook.</a></strong></p>
-                <p class="sources">Sources: <a href="https://cw118.github.io/quetudesinfo/links">official CEGEP sites and viewbooks</a></p>
+                <p>This is a very general and incomplete list meant to give you an idea of what kinds of programs CEGEPs may offer. For a bit more information on this site, try <a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>. <strong>For full details on a CEGEP and their prorams, <a href="links.html">visit their official site and/or see their viewbook.</a></strong></p>
+                <p class="sources">Sources: <a href="/quetudesinfo/links">official CEGEP sites and viewbooks</a></p>
 
                 <h2 id="technical-programs" class="yellow-bg">Career and Technical Programs</h2>
                 <p class="p-disclaimer"><i class="fas fa-info-circle"></i> Program and/or profile names and prerequisites may vary with different colleges. This is <u>not</u> a full list of programs.</p>
@@ -355,7 +355,7 @@
                     <li><strong>Graphic Communications:</strong> prepress computer graphics and printing</li>
                 </ul>
                 <p class="p-disclaimer">Technical programs tend to be slightly different at every college, especially if a profile/option of the program is
-                specified in its name. Some are also only offered in either the Fall or Winter semester. <a href="https://cw118.github.io/quetudesinfo/links">Viewbooks</a> are a great resource
+                specified in its name. Some are also only offered in either the Fall or Winter semester. <a href="/quetudesinfo/links">Viewbooks</a> are a great resource
                 to see technical program specifications.</p>
                 <p>Since there are far too many technical programs for this page to include them all, <strong>here are some common career and technical programs:</strong></p>
                 
@@ -488,8 +488,8 @@
                     </div>                    
                 </div><hr>
 
-                <p>This is a very general and incomplete list meant to give you an idea of what kinds of programs CEGEPs may offer. For a bit more information on this site, try <a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>. <strong>For full details on a CEGEP and their prorams, <a href=https://cw118.github.io/quetudesinfo/links">visit their official site and/or see their viewbook.</a></strong></p>
-                <p class="sources">Sources: <a href="https://www.sram.qc.ca/international-student/curricula-and-levels">SRAM</a>, <a href="https://www.cegepsquebec.ca/">Cégeps du Québec</a>, <a href="https://cw118.github.io/quetudesinfo/links">official CEGEP sites and viewbooks</a></p>
+                <p>This is a very general and incomplete list meant to give you an idea of what kinds of programs CEGEPs may offer. For a bit more information on this site, try <a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a>. <strong>For full details on a CEGEP and their prorams, <a href=https://cw118.github.io/quetudesinfo/links">visit their official site and/or see their viewbook.</a></strong></p>
+                <p class="sources">Sources: <a href="https://www.sram.qc.ca/international-student/curricula-and-levels">SRAM</a>, <a href="https://www.cegepsquebec.ca/">Cégeps du Québec</a>, <a href="/quetudesinfo/links">official CEGEP sites and viewbooks</a></p>
 
                 <h2 id="special-programs" class="lightblue-bg">Special programs, partnerships, and opportunities</h2>
                 <p class="p-disclaimer lightyellow-bg"><i class="fas fa-info-circle"></i> Not all possibilities are included, and not all CEGEPs offer what's mentioned here.</p>
@@ -518,14 +518,14 @@
                 a French CEGEP. Research your colleges and programs of interest carefully for more information.</p>
                 <p><strong>Exchange programs</strong> — some CEGEPs have international exchange programs that allow you to visit and study in another country. Research your
                 colleges and programs of interest carefully for more information.</p>
-                <p class="sources">Sources: <a href="https://alliancesportetudes.ca/en/alliance-sport-etudes/about/">Alliance Sport-Études</a>, <a href="https://cw118.github.io/quetudesinfo/links">various CEGEP sites</a></p>
+                <p class="sources">Sources: <a href="https://alliancesportetudes.ca/en/alliance-sport-etudes/about/">Alliance Sport-Études</a>, <a href="/quetudesinfo/links">various CEGEP sites</a></p>
 
                 <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
 
                 <div class="pagination" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="btn btn-warning previous">&#8592; Previous</a>
+                    <a href="/quetudesinfo/whatiscegep" class="btn btn-warning previous">&#8592; Previous</a>
                     <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/whatiscegep/english-cegeps" class="btn btn-warning next">Next &#8594;</a>
                 </div>
 
             </section>
@@ -535,23 +535,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>

--- a/whatiscegep/r-score.html
+++ b/whatiscegep/r-score.html
@@ -48,50 +48,50 @@
 
             <div id="header">
                 <div class="banner">
-                    <a href="https://cw118.github.io/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
+                    <a href="/quetudesinfo/"><img src="../assets/Q-info-logo-small.jpg" alt="QUÉtudes-info" loading="lazy"
                             id="logo"></a>
                 </div>
                 <div class="header-right">
-                    <a id="header-help" href="https://cw118.github.io/quetudesinfo/help">Help</a>
-                    <a id="header-disclaimers" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
-                    <a id="header-terms" href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
-                    <a id="header-contact" href="https://cw118.github.io/quetudesinfo/contact">Contact</a>
+                    <a id="header-help" href="/quetudesinfo/help">Help</a>
+                    <a id="header-disclaimers" href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a>
+                    <a id="header-terms" href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a>
+                    <a id="header-contact" href="/quetudesinfo/contact">Contact</a>
                 </div>
             </div>
 
             <nav class="topnav">
                 <div id="topnav-end">
                     <ul class="nav-links">
-                        <li><a href="https://cw118.github.io/quetudesinfo/" id="menu-home">Home</a></li>
+                        <li><a href="/quetudesinfo/" id="menu-home">Home</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/whatiscegep" class="active">What is CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/whatiscegep" class="active">What is CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown1">
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/programs">Programs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/r-score">The R-Score</a></li>
+                                <li><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></li>
                             </ul>
                         </li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
+                            <a href="/quetudesinfo/apply">Applying to CEGEP &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown2">
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/important-dates">Important Dates</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/apply/after-applying">After applying</a></li>
+                                <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                                <li><a href="/quetudesinfo/apply/make-smart-choices">Making smart choices</a></li>
+                                <li><a href="/quetudesinfo/apply/important-dates">Important Dates</a></li>
+                                <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                                <li><a href="/quetudesinfo/apply/after-applying">After applying</a></li>
                             </ul>
                         </li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links" id="menu-links">Important Links</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/resources" id="menu-resources">Resources</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/links" id="menu-links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/resources" id="menu-resources">Resources</a></li>
                         <li>
-                            <a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
+                            <a href="/quetudesinfo/about/disclaimers-terms">About &#9662;</a>
                             <ul class="dropdown" id="nav-dropdown3">
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
-                                <li><a href="https://cw118.github.io/quetudesinfo/about/about-me">About the site creator</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#disclaimers">Disclaimers</a></li>
+                                <li><a href="/quetudesinfo/about/disclaimers-terms#terms">Terms of Use</a></li>
+                                <li><a href="/quetudesinfo/about/about-project">QUÉtudes-info: The Project</a></li>
+                                <li><a href="/quetudesinfo/about/about-me">About the site creator</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -113,17 +113,17 @@
                 <a class="nav-link" href="#references">References</a>
                 <hr>
                 <p class="sidenav-title">In this section</p>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep">What is CEGEP</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">Programs</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>
-                <a class="nav-link active" href="https://cw118.github.io/quetudesinfo/whatiscegep/r-score">The R-Score</a>
-                <a class="nav-link" href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep">What is CEGEP</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/programs">Programs</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a>
+                <a class="nav-link active" href="/quetudesinfo/whatiscegep/r-score">The R-Score</a>
+                <a class="nav-link" href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a>
             </nav>
 
             <section>
                 <div class="pagination mb-2" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps" class="btn btn-warning previous">&#8592; Previous</a>
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/whatiscegep/english-cegeps" class="btn btn-warning previous">&#8592; Previous</a>
+                    <a href="/quetudesinfo/whatiscegep/cegep-alternatives" class="btn btn-warning next">Next &#8594;</a>
                 </div>
                 <h2 class="lightblue-bg" id="r-score">The R-Score</h2>
                 <p><strong>The R-Score</strong>, officially the <em>cote de rendement au collégial (CRC)</em>, is <strong>a number or score you receive for each course you take in CEGEP</strong>. It's used for <strong>university admissions in
@@ -450,19 +450,19 @@
                 <p>To learn more about the R-Score (all documents) from BCI, the body responsible for its calculation, visit their site: <a href="https://www.bci-qc.ca/en/r-score/" target="_blank">https://www.bci-qc.ca/en/r-score/</a></p>
                 <hr>
                 <p><strong>Want to find out how to apply to CEGEP, or get some tips on choosing a college and program?</strong></p>
-                <p><a href="https://cw118.github.io/quetudesinfo/apply" class="btn btn-primary">Applying to CEGEP</a></p>
+                <p><a href="/quetudesinfo/apply" class="btn btn-primary">Applying to CEGEP</a></p>
                 <p><strong>Looking to visit the official CEGEP sites, or looking for viewbooks, handbooks, and more?</strong></p>
-                <p><a href="https://cw118.github.io/quetudesinfo/links" class="btn btn-dark">Important Links</a></p>
+                <p><a href="/quetudesinfo/links" class="btn btn-dark">Important Links</a></p>
                 <p><strong>Not sure where to go next?</strong></p>
-                <p><a href="https://cw118.github.io/quetudesinfo/help" class="btn btn-info">Help</a> <em>or</em> <a href="https://cw118.github.io/quetudesinfo/" class="btn btn-outline-info">QUÉtudes-info Home</a></p>
-                <p><strong>Think CEGEP might not be for you?</strong> Continue to <strong><a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></strong>.</p>
+                <p><a href="/quetudesinfo/help" class="btn btn-info">Help</a> <em>or</em> <a href="/quetudesinfo/" class="btn btn-outline-info">QUÉtudes-info Home</a></p>
+                <p><strong>Think CEGEP might not be for you?</strong> Continue to <strong><a href="/quetudesinfo/whatiscegep/cegep-alternatives">Alternatives to CEGEP</a></strong>.</p>
 
                 <a href="#" class="gotopbtn" role="button"><i class="fas fa-arrow-up"></i></a>
 
                 <div class="pagination" role="navigation">
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps" class="btn btn-warning previous">&#8592; Previous</a>
+                    <a href="/quetudesinfo/whatiscegep/english-cegeps" class="btn btn-warning previous">&#8592; Previous</a>
                     <a href="#" class="btn btn-secondary back-to-top">Back to top &#8593;</a>
-                    <a href="https://cw118.github.io/quetudesinfo/whatiscegep/cegep-alternatives" class="btn btn-warning next">Next &#8594;</a>
+                    <a href="/quetudesinfo/whatiscegep/cegep-alternatives" class="btn btn-warning next">Next &#8594;</a>
                 </div>
 
             </section>
@@ -472,23 +472,23 @@
             <div class="footer-row">
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/english-cegeps">English-language CEGEPs</a></li>
+                        <li><a href="/quetudesinfo/whatiscegep/programs">CEGEP Programs</a></li>
+                        <li><a href="/quetudesinfo/compare-programs">Program Comparison Tool</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/apply/application-systems">Application Systems</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/links">Important Links</a></li>
+                        <li><a href="/quetudesinfo/apply/choose-a-cegep-program">Choosing a CEGEP and Program</a></li>
+                        <li><a href="/quetudesinfo/apply/application-systems">Application Systems</a></li>
+                        <li><a href="/quetudesinfo/links">Important Links</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <ul>
-                        <li><a href="https://cw118.github.io/quetudesinfo/help">Help</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
-                        <li><a href="https://cw118.github.io/quetudesinfo/about/about-project">About the project</a></li>
+                        <li><a href="/quetudesinfo/help">Help</a></li>
+                        <li><a href="/quetudesinfo/about/disclaimers-terms">Disclaimers and Terms</a></li>
+                        <li><a href="/quetudesinfo/about/about-project">About the project</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Replaces absolute links leading to QUÉtudes-info pages and headings with relative paths (primarily involved removing the `https://cw118.github.io` portion of anchor `href`s)

Fixes #16 